### PR TITLE
feat: visually highlight working sets vs warm-ups

### DIFF
--- a/apps/workout-log/src/app/history/set-intensity.spec.ts
+++ b/apps/workout-log/src/app/history/set-intensity.spec.ts
@@ -1,0 +1,72 @@
+import {describe, expect, it} from 'vitest'
+import {WorkoutRow} from "../workout";
+import {classifySessionSets} from "./set-intensity";
+
+function row(id: string, weight: number, overrides?: { exercise?: string, reps?: number }): WorkoutRow {
+    return {
+        id,
+        value: {
+            exercise: overrides?.exercise ?? "Trap bar deadlift",
+            reps: overrides?.reps ?? 8,
+            weight,
+            date: 0,
+        }
+    };
+}
+
+describe('classifySessionSets', () => {
+    it('returns an empty classification for no sets', () => {
+        expect(classifySessionSets([]).size).toEqual(0);
+    })
+
+    it('marks the only set as working', () => {
+        const map = classifySessionSets([row("1", 100)]);
+
+        expect(map.get("1")).toEqual("working");
+    })
+
+    it('marks the top-weight sets working and the lighter ramp-up sets as warmup', () => {
+        // ordered most-recent-first, like a rendered session
+        const sets = [
+            row("5", 100),
+            row("4", 100),
+            row("3", 100),
+            row("2", 80),
+            row("1", 60),
+        ];
+
+        const map = classifySessionSets(sets);
+
+        expect(map.get("5")).toEqual("working");
+        expect(map.get("4")).toEqual("working");
+        expect(map.get("3")).toEqual("working");
+        expect(map.get("2")).toEqual("warmup");
+        expect(map.get("1")).toEqual("warmup");
+    })
+
+    it('treats every set as working when they all share the same weight', () => {
+        const sets = [row("2", 67.5), row("1", 67.5)];
+
+        const map = classifySessionSets(sets);
+
+        expect(map.get("2")).toEqual("working");
+        expect(map.get("1")).toEqual("working");
+    })
+
+    it('classifies each exercise independently within the same session', () => {
+        // a deadlift working weight must not make a lighter bench press look like a warmup
+        const sets = [
+            row("4", 100, {exercise: "Trap bar deadlift"}),
+            row("3", 60, {exercise: "Trap bar deadlift"}),
+            row("2", 67.5, {exercise: "Barred bench press"}),
+            row("1", 60, {exercise: "Barred bench press"}),
+        ];
+
+        const map = classifySessionSets(sets);
+
+        expect(map.get("4")).toEqual("working"); // deadlift top
+        expect(map.get("3")).toEqual("warmup");  // deadlift ramp-up
+        expect(map.get("2")).toEqual("working"); // bench top, despite being lighter than the deadlift
+        expect(map.get("1")).toEqual("warmup");  // bench ramp-up
+    })
+})

--- a/apps/workout-log/src/app/history/set-intensity.ts
+++ b/apps/workout-log/src/app/history/set-intensity.ts
@@ -1,0 +1,30 @@
+import {WorkoutRow} from "../workout";
+
+export type SetIntensity = 'working' | 'warmup';
+
+/**
+ * Classifies each set of a session as a working set or a warm-up, purely from the logged weights.
+ *
+ * Within a session the heaviest weight reached for a given exercise is taken as its working weight;
+ * sets at that weight are `working`, lighter ramp-up sets below it are `warmup`. Each exercise is
+ * judged on its own, so a light exercise is never dimmed just because a heavier one shares the
+ * session. When every set of an exercise is the same weight they all count as working.
+ *
+ * Returns a map keyed by workout id.
+ */
+export function classifySessionSets(workouts: WorkoutRow[]): Map<string, SetIntensity> {
+    const workingWeightByExercise = new Map<string, number>();
+    for (const workout of workouts) {
+        const currentMax = workingWeightByExercise.get(workout.value.exercise);
+        if (currentMax === undefined || workout.value.weight > currentMax) {
+            workingWeightByExercise.set(workout.value.exercise, workout.value.weight);
+        }
+    }
+
+    const classification = new Map<string, SetIntensity>();
+    for (const workout of workouts) {
+        const workingWeight = workingWeightByExercise.get(workout.value.exercise)!;
+        classification.set(workout.id, workout.value.weight >= workingWeight ? 'working' : 'warmup');
+    }
+    return classification;
+}

--- a/apps/workout-log/src/app/history/workout-short-history.tsx
+++ b/apps/workout-log/src/app/history/workout-short-history.tsx
@@ -3,6 +3,7 @@ import {WorkoutRow} from "../workout";
 import {RemoveWorkoutButton} from "./remove-workout-button";
 import {formatNarrowSmartly} from "../utils/date-utils";
 import {groupWorkoutsIntoSessions} from "./workout-session";
+import {classifySessionSets} from "./set-intensity";
 
 interface WorkoutHistoryProps {
     workoutList: WorkoutRow[],
@@ -26,7 +27,9 @@ export default function WorkoutShortHistory(props: WorkoutHistoryProps) {
             <h3 className="text-center">last workouts</h3>
             <div id="workout-history">
                 {
-                    sessions.map((session) => (
+                    sessions.map((session) => {
+                    const setIntensity = classifySessionSets(session.workouts);
+                    return (
                         <section id="workout-session" key={session.startDate} className="mt-4">
                             <h4 className="text-xs uppercase tracking-wide text-gray-400 border-b border-gray-200 dark:border-gray-700 pb-1">
                                 {formatNarrowSmartly(session.endDate)}
@@ -35,7 +38,9 @@ export default function WorkoutShortHistory(props: WorkoutHistoryProps) {
                             <ul role="list" className="divide-y divide-gray-200 dark:divide-gray-700">
                                 {
                                     session.workouts.map((workout) => (
-                                        <li id="workout-history-entry" key={workout.id} className="py-3 sm:py-4">
+                                        <li id="workout-history-entry" key={workout.id}
+                                            className={`py-3 sm:py-4 transition-opacity ${setIntensity.get(workout.id) === "warmup" ? "opacity-40" : ""}`}
+                                            title={setIntensity.get(workout.id) === "warmup" ? "warm-up set" : undefined}>
                                             <div className="flex flex-row space-x-4 justify-between">
 
                                                 <div className="text-gray-500">
@@ -69,7 +74,8 @@ export default function WorkoutShortHistory(props: WorkoutHistoryProps) {
                                 }
                             </ul>
                         </section>
-                    ))
+                    );
+                    })
                 }
             </div>
         </div>


### PR DESCRIPTION
## What

Within each session, warm-up (ramp-up) sets are dimmed slightly so the **working sets** stand out. Purely visual — no new data, no user input.

Example: a `60 → 80 → 100 → 100 → 100` deadlift session shows the three `100 kg` sets at full opacity and the `60`/`80` ramp-up sets faded.

## How

- `set-intensity.ts` — pure `classifySessionSets(workouts)`: for each exercise **within the session**, the heaviest logged weight is the working weight; sets at it are `working`, lighter ones `warmup`. Returns a map keyed by workout id.
- `workout-short-history.tsx` — applies `opacity-40` (+ `transition-opacity`, `title="warm-up set"`) to warm-up rows.

Design choices:
- **Per-exercise**, so a lighter exercise isn't dimmed just because a heavier one shares the session.
- **Uniform-weight sessions dim nothing** (all sets are working) — keeps it discrete.
- Weight is the signal, not reps (working sets vary in reps: 6/6/6/7).

## Tested (TDD)

`set-intensity.spec.ts`, written first: empty, single set, ramp-up split, all-same-weight, and multi-exercise-in-one-session.

`33 passed` in production mode (`NODE_ENV=production`, matching Vercel); `tsc --noEmit` clean.