### PR TITLE
feat: optional RPE (1-10) on workout logs

### DIFF
--- a/apps/workout-log/src/app/firestore/WorkoutFirestore.ts
+++ b/apps/workout-log/src/app/firestore/WorkoutFirestore.ts
@@ -21,17 +21,20 @@ export async function add(userId: string, workout: Workout, db: Firestore) {
         const [mostRecent] = await getMostRecents(db, userId, 1);
         const sessionId = resolveSessionId(workout.date, mostRecent, generateSessionId());
 
-        await addDoc(
-            collection(db, WORKOUT_LOG_COLLECTION),
-            {
-                weight: workout.weight,
-                date: workout.date,
-                reps: workout.reps,
-                exercise: workout.exercise,
-                sessionId: sessionId,
-                userId: userId
-            }
-        );
+        const workoutDoc: Record<string, any> = {
+            weight: workout.weight,
+            date: workout.date,
+            reps: workout.reps,
+            exercise: workout.exercise,
+            sessionId: sessionId,
+            userId: userId
+        };
+        // Firestore rejects `undefined` fields, so only include RPE when it was actually set.
+        if (workout.rpe !== undefined) {
+            workoutDoc.rpe = workout.rpe;
+        }
+
+        await addDoc(collection(db, WORKOUT_LOG_COLLECTION), workoutDoc);
     } catch
         (e: any) {
         console.error('Unsuccessful', e)

--- a/apps/workout-log/src/app/form/log-form.tsx
+++ b/apps/workout-log/src/app/form/log-form.tsx
@@ -1,6 +1,7 @@
 import React, {FocusEvent, useState} from "react";
 import {Workout} from "../workout";
 import {noop} from "../noop";
+import {RPE_MAX, RPE_MIN, sanitizeRpe} from "../model/rpe";
 
 interface LogFormProps {
     onWorkoutLog?: (e: { workout: Workout }) => void;
@@ -14,6 +15,8 @@ export default function LogForm(props: LogFormProps) {
     const [exercise, setExercise] = useState(lastWorkoutInput ? lastWorkoutInput.exercise : "deadlift");
     const [reps, setReps] = useState(lastWorkoutInput ? lastWorkoutInput.reps : 10);
     const [weight, setWeight] = useState(lastWorkoutInput ? lastWorkoutInput.weight : 80);
+    // RPE is optional and set-specific, so it always starts blank rather than carrying over.
+    const [rpe, setRpe] = useState<string>("");
 
     const [isLoading, setIsLoading] = useState<boolean>(false)
     const [error, setError] = useState<string | null>(null)
@@ -45,7 +48,8 @@ export default function LogForm(props: LogFormProps) {
                     exercise,
                     reps,
                     weight,
-                    date: Date.now()
+                    date: Date.now(),
+                    rpe: sanitizeRpe(rpe)
                 }
             });
 
@@ -121,6 +125,25 @@ export default function LogForm(props: LogFormProps) {
                     }
                     onFocus={selectAllInputOnFocus}
                     required
+                />
+            </div>
+            <div className={"form-element"}>
+                <label htmlFor="rpe" className="block text-sm font-medium leading-6">
+                    RPE <span className="text-xs font-normal text-gray-400">(optional)</span>
+                </label>
+                <input
+                    type="number"
+                    name="rpe"
+                    id="rpe"
+                    value={rpe}
+                    min={RPE_MIN}
+                    max={RPE_MAX}
+                    step={1}
+                    placeholder={`${RPE_MIN}-${RPE_MAX}`}
+                    onChange={(e) =>
+                        setRpe(e.target.value)
+                    }
+                    onFocus={selectAllInputOnFocus}
                 />
             </div>
             <div className={"form-element content-center"}>

--- a/apps/workout-log/src/app/history/workout-short-history.tsx
+++ b/apps/workout-log/src/app/history/workout-short-history.tsx
@@ -60,6 +60,13 @@ export default function WorkoutShortHistory(props: WorkoutHistoryProps) {
                                                         {workout.value.weight}
                                                         <p className="text-gray-500 text-sm">kg</p>
                                                     </div>
+                                                    {workout.value.rpe !== undefined ?
+                                                        <div className="inline-flex items-center text-sm text-gray-400"
+                                                             title="Rate of Perceived Exertion">
+                                                            @{workout.value.rpe}
+                                                        </div>
+                                                        : <></>
+                                                    }
                                                     <div>
                                                         {onWorkoutDelete ?
                                                             <RemoveWorkoutButton

--- a/apps/workout-log/src/app/model/rpe.spec.ts
+++ b/apps/workout-log/src/app/model/rpe.spec.ts
@@ -1,0 +1,31 @@
+import {describe, expect, it} from 'vitest'
+import {RPE_MAX, RPE_MIN, sanitizeRpe} from "./rpe";
+
+describe('sanitizeRpe', () => {
+    it('treats blank / missing input as "no RPE"', () => {
+        expect(sanitizeRpe(undefined)).toBeUndefined();
+        expect(sanitizeRpe(null)).toBeUndefined();
+        expect(sanitizeRpe("")).toBeUndefined();
+        expect(sanitizeRpe("   ")).toBeUndefined();
+        expect(sanitizeRpe(NaN)).toBeUndefined();
+    })
+
+    it('accepts an integer within 1..10 from a number or a string', () => {
+        expect(sanitizeRpe(8)).toEqual(8);
+        expect(sanitizeRpe("8")).toEqual(8);
+        expect(sanitizeRpe(RPE_MIN)).toEqual(1);
+        expect(sanitizeRpe(RPE_MAX)).toEqual(10);
+    })
+
+    it('rejects values outside the 1..10 range', () => {
+        expect(sanitizeRpe(0)).toBeUndefined();
+        expect(sanitizeRpe(11)).toBeUndefined();
+        expect(sanitizeRpe(-3)).toBeUndefined();
+        expect(sanitizeRpe("100")).toBeUndefined();
+    })
+
+    it('rejects non-integer values', () => {
+        expect(sanitizeRpe(7.5)).toBeUndefined();
+        expect(sanitizeRpe("abc")).toBeUndefined();
+    })
+})

--- a/apps/workout-log/src/app/model/rpe.ts
+++ b/apps/workout-log/src/app/model/rpe.ts
@@ -1,0 +1,22 @@
+export const RPE_MIN = 1;
+export const RPE_MAX = 10;
+
+/**
+ * Normalizes a raw RPE (Rate of Perceived Exertion) input into a stored value.
+ * RPE is optional, so anything blank, non-numeric, non-integer, or outside 1..10 becomes
+ * `undefined` ("no RPE recorded") rather than an error — the log is still valid without it.
+ */
+export function sanitizeRpe(value: unknown): number | undefined {
+    if (value === undefined || value === null) {
+        return undefined;
+    }
+    if (typeof value === "string" && value.trim() === "") {
+        return undefined;
+    }
+
+    const rpe = typeof value === "number" ? value : Number(value);
+    if (!Number.isInteger(rpe) || rpe < RPE_MIN || rpe > RPE_MAX) {
+        return undefined;
+    }
+    return rpe;
+}

--- a/apps/workout-log/src/app/workout.ts
+++ b/apps/workout-log/src/app/workout.ts
@@ -6,6 +6,8 @@ export interface Workout {
     // Id of the gym session this log belongs to, resolved and persisted at creation time.
     // Optional because logs created before this feature don't have one.
     sessionId?: string,
+    // Rate of Perceived Exertion (1..10). Optional — logs may be recorded without it.
+    rpe?: number,
 }
 
 export interface WorkoutRow {


### PR DESCRIPTION
## What

Adds an **optional** RPE (Rate of Perceived Exertion, 1–10) to each workout log. Logging without it works exactly as before.

## How

- `model/rpe.ts` — pure `sanitizeRpe(value)`: normalizes raw input to an integer in `1..10`, or `undefined` when blank / non-numeric / non-integer / out of range. So an invalid or empty RPE just means "not recorded", never an error.
- `form/log-form.tsx` — optional number input (`min=1 max=10 step=1`, not `required`), labelled "RPE (optional)". Starts blank every time — RPE is set-specific, so it deliberately doesn't carry over from the last log like weight/reps do.
- `firestore/WorkoutFirestore.ts` — writes `rpe` only when set (Firestore rejects `undefined` fields).
- `history/workout-short-history.tsx` — shows `@N` discreetly on a row when an RPE was recorded.
- `workout.ts` — `Workout.rpe?: number` (optional, backward compatible with existing docs and the stats function that imports this type).

## Tested (TDD)

`rpe.spec.ts`, written first: blank/missing → undefined, integer 1..10 from number or string, out-of-range rejected, non-integer rejected.

`37 passed` in production mode (`NODE_ENV=production`, matching Vercel); `tsc --noEmit` clean for both apps.

## Note

Kept to integer 1–10 per the request. Half-step RPE (6.5, 7.5, …) would be a one-line change to `sanitizeRpe` if you want it later.