### PR TITLE
feat: colored RPE scale picker + tighter mobile form

### DIFF
--- a/apps/workout-log/e2e/home-page-helper.ts
+++ b/apps/workout-log/e2e/home-page-helper.ts
@@ -32,7 +32,8 @@ export class HomePageHelper {
     }
 
     async submitWorkoutLog(workoutInput: { exercise: string, reps: number, weight: number }) {
-        await this.page.getByLabel('exercise').fill(workoutInput.exercise);
+        // target by id: getByLabel('exercise') also matches the "Exercise history" button's aria-label
+        await this.page.locator('#exercise').fill(workoutInput.exercise);
         await this.page.getByLabel('reps').fill(workoutInput.reps.toString());
         await this.page.getByLabel('weight').fill(workoutInput.weight.toString());
         await this.page.locator("[type=submit]").click();

--- a/apps/workout-log/src/app/form/log-form.tsx
+++ b/apps/workout-log/src/app/form/log-form.tsx
@@ -1,22 +1,33 @@
 import React, {FocusEvent, useState} from "react";
 import {Workout} from "../workout";
 import {noop} from "../noop";
-import {RPE_MAX, RPE_MIN, sanitizeRpe} from "../model/rpe";
+import {sanitizeRpe} from "../model/rpe";
+import RpeSelector from "./rpe-selector";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {faClockRotateLeft} from "@fortawesome/free-solid-svg-icons";
 
 interface LogFormProps {
     onWorkoutLog?: (e: { workout: Workout }) => void;
     onExerciseSelected?: (e: { exercise: string }) => void;
     lastWorkoutInput: Workout | undefined;
+    onShowExerciseHistory?: () => void;
+    canShowExerciseHistory?: boolean;
 }
 
 export default function LogForm(props: LogFormProps) {
-    const {onWorkoutLog = noop, onExerciseSelected = noop, lastWorkoutInput} = props;
+    const {
+        onWorkoutLog = noop,
+        onExerciseSelected = noop,
+        lastWorkoutInput,
+        onShowExerciseHistory = noop,
+        canShowExerciseHistory = false,
+    } = props;
 
     const [exercise, setExercise] = useState(lastWorkoutInput ? lastWorkoutInput.exercise : "deadlift");
     const [reps, setReps] = useState(lastWorkoutInput ? lastWorkoutInput.reps : 10);
     const [weight, setWeight] = useState(lastWorkoutInput ? lastWorkoutInput.weight : 80);
     // RPE is optional and set-specific, so it always starts blank rather than carrying over.
-    const [rpe, setRpe] = useState<string>("");
+    const [rpe, setRpe] = useState<number | undefined>(undefined);
 
     const [isLoading, setIsLoading] = useState<boolean>(false)
     const [error, setError] = useState<string | null>(null)
@@ -72,7 +83,7 @@ export default function LogForm(props: LogFormProps) {
 
     return (
         <form
-            className='log-form flex flex-col items-center border-b border-gray-900/10 pb-6  gap-x-6 gap-y-8 sm:grid-cols-6'
+            className='log-form flex flex-col items-center border-b border-gray-900/10 pb-4 gap-x-6 gap-y-3 sm:grid-cols-6'
             onSubmit={(e) => onSubmit(e)}
         >
             {error && <div style={{color: 'red'}}>{error}</div>}
@@ -127,26 +138,13 @@ export default function LogForm(props: LogFormProps) {
                     required
                 />
             </div>
-            <div className={"form-element"}>
-                <label htmlFor="rpe" className="block text-sm font-medium leading-6">
+            <div className="form-element w-full">
+                <label htmlFor="rpe-selector" className="block text-sm font-medium leading-6">
                     RPE <span className="text-xs font-normal text-gray-400">(optional)</span>
                 </label>
-                <input
-                    type="number"
-                    name="rpe"
-                    id="rpe"
-                    value={rpe}
-                    min={RPE_MIN}
-                    max={RPE_MAX}
-                    step={1}
-                    placeholder={`${RPE_MIN}-${RPE_MAX}`}
-                    onChange={(e) =>
-                        setRpe(e.target.value)
-                    }
-                    onFocus={selectAllInputOnFocus}
-                />
+                <RpeSelector value={rpe} onChange={setRpe}/>
             </div>
-            <div className={"form-element content-center"}>
+            <div className="form-element content-center flex flex-row items-center gap-3">
                 <button
                     className="rounded-md bg-main px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-main/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
                     type="submit"
@@ -154,6 +152,17 @@ export default function LogForm(props: LogFormProps) {
                     disabled={isLoading}>
                     {isLoading ? 'Loading...' : 'Submit'}
                 </button>
+                {canShowExerciseHistory ?
+                    <button
+                        type="button"
+                        onClick={onShowExerciseHistory}
+                        title="Exercise history"
+                        aria-label="Exercise history"
+                        className="rounded-md border border-main px-3 py-2 text-sm font-semibold text-main shadow-sm hover:bg-main/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
+                        <FontAwesomeIcon icon={faClockRotateLeft}/>
+                    </button>
+                    : <></>
+                }
             </div>
         </form>
     );

--- a/apps/workout-log/src/app/form/rpe-selector.tsx
+++ b/apps/workout-log/src/app/form/rpe-selector.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import {RPE_VALUES, rpeColor} from "../model/rpe";
+
+interface RpeSelectorProps {
+    value: number | undefined;
+    onChange: (rpe: number | undefined) => void;
+}
+
+/**
+ * Optional RPE picker: ten colour-coded buttons on a grey→green→yellow→red effort scale.
+ * Tapping the selected value again clears it, since RPE is optional.
+ */
+export default function RpeSelector({value, onChange}: RpeSelectorProps) {
+    return (
+        <div id="rpe-selector" role="group" aria-label="RPE" className="flex flex-row gap-1 w-full">
+            {RPE_VALUES.map((n) => {
+                const selected = value === n;
+                return (
+                    <button
+                        key={n}
+                        type="button"
+                        aria-label={`RPE ${n}`}
+                        aria-pressed={selected}
+                        title={`RPE ${n}`}
+                        onClick={() => onChange(selected ? undefined : n)}
+                        style={{backgroundColor: rpeColor(n)}}
+                        className={`flex-1 h-8 rounded text-xs font-semibold text-black/70 transition-transform ${
+                            selected ? "ring-2 ring-offset-1 ring-gray-600 scale-110" : "opacity-40 hover:opacity-70"
+                        }`}
+                    >
+                        {n}
+                    </button>
+                );
+            })}
+        </div>
+    );
+}

--- a/apps/workout-log/src/app/history/workout-short-history.tsx
+++ b/apps/workout-log/src/app/history/workout-short-history.tsx
@@ -4,6 +4,7 @@ import {RemoveWorkoutButton} from "./remove-workout-button";
 import {formatNarrowSmartly} from "../utils/date-utils";
 import {groupWorkoutsIntoSessions} from "./workout-session";
 import {classifySessionSets} from "./set-intensity";
+import {rpeColor} from "../model/rpe";
 
 interface WorkoutHistoryProps {
     workoutList: WorkoutRow[],
@@ -61,9 +62,10 @@ export default function WorkoutShortHistory(props: WorkoutHistoryProps) {
                                                         <p className="text-gray-500 text-sm">kg</p>
                                                     </div>
                                                     {workout.value.rpe !== undefined ?
-                                                        <div className="inline-flex items-center text-sm text-gray-400"
+                                                        <div className="inline-flex items-center justify-center rounded px-1.5 text-xs font-semibold text-black/70"
+                                                             style={{backgroundColor: rpeColor(workout.value.rpe)}}
                                                              title="Rate of Perceived Exertion">
-                                                            @{workout.value.rpe}
+                                                            {workout.value.rpe}
                                                         </div>
                                                         : <></>
                                                     }

--- a/apps/workout-log/src/app/home.tsx
+++ b/apps/workout-log/src/app/home.tsx
@@ -83,7 +83,7 @@ export default function Home(props: HomeProps) {
 
     const subtitle = <p className="text-xs">{appShortDescription}</p>
     return (
-        <main className="flex min-h-screen flex-col items-center justify-between p-10 pt-6">
+        <main className="flex min-h-screen flex-col items-center justify-between p-5 pt-4 sm:p-10 sm:pt-6">
             <div>
 
 
@@ -128,19 +128,11 @@ export default function Home(props: HomeProps) {
                                     ref={clockWatchChildRef}></ClockWatch>
                         <div>
                             <LogForm onWorkoutLog={onWorkoutLog} onExerciseSelected={onExerciseSelected}
-                                     lastWorkoutInput={getLastWorkoutInputInLocalStorage()}>
+                                     lastWorkoutInput={getLastWorkoutInputInLocalStorage()}
+                                     canShowExerciseHistory={!!currentSelectedExercise}
+                                     onShowExerciseHistory={() => setDisplayWorkoutHistoryPage(true)}>
                             </LogForm>
                         </div>
-                        {currentSelectedExercise ?
-                            <div className="flex justify-center">
-                                <button
-                                    onClick={() => setDisplayWorkoutHistoryPage(true)}
-                                    className="justify-center rounded-md bg-main px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-main/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">
-                                    Exercise history
-                                </button>
-                            </div>
-                            : <></>
-                        }
                         <WorkoutShortHistory workoutList={workoutRecentHistory}
                                              onWorkoutDelete={workoutId => onWorkoutDelete(workoutId)}></WorkoutShortHistory>
                     </>

--- a/apps/workout-log/src/app/model/rpe.spec.ts
+++ b/apps/workout-log/src/app/model/rpe.spec.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest'
-import {RPE_MAX, RPE_MIN, sanitizeRpe} from "./rpe";
+import {RPE_MAX, RPE_MIN, RPE_VALUES, rpeColor, sanitizeRpe} from "./rpe";
 
 describe('sanitizeRpe', () => {
     it('treats blank / missing input as "no RPE"', () => {
@@ -27,5 +27,27 @@ describe('sanitizeRpe', () => {
     it('rejects non-integer values', () => {
         expect(sanitizeRpe(7.5)).toBeUndefined();
         expect(sanitizeRpe("abc")).toBeUndefined();
+    })
+})
+
+describe('rpeColor', () => {
+    it('exposes the ten selectable values 1..10', () => {
+        expect(RPE_VALUES).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    })
+
+    it('returns a hex colour for every RPE value', () => {
+        for (const value of RPE_VALUES) {
+            expect(rpeColor(value)).toMatch(/^#[0-9a-f]{6}$/i);
+        }
+    })
+
+    it('ramps from grey at the bottom to red at the top', () => {
+        expect(rpeColor(RPE_MIN)).toEqual('#9ca3af');
+        expect(rpeColor(RPE_MAX)).toEqual('#dc2626');
+    })
+
+    it('clamps out-of-range values to the nearest end of the scale', () => {
+        expect(rpeColor(0)).toEqual(rpeColor(RPE_MIN));
+        expect(rpeColor(42)).toEqual(rpeColor(RPE_MAX));
     })
 })

--- a/apps/workout-log/src/app/model/rpe.ts
+++ b/apps/workout-log/src/app/model/rpe.ts
@@ -1,6 +1,31 @@
 export const RPE_MIN = 1;
 export const RPE_MAX = 10;
 
+export const RPE_VALUES = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+// Effort scale: grey (easy) → green → yellow → red (maximal), one colour per RPE 1..10.
+const RPE_COLORS = [
+    '#9ca3af', // 1  grey
+    '#4ade80', // 2  green
+    '#a3e635', // 3  light green
+    '#d9e021', // 4  yellow-green
+    '#facc15', // 5  yellow
+    '#fbbf24', // 6  amber
+    '#f59e0b', // 7  dark amber
+    '#f97316', // 8  orange
+    '#ef4444', // 9  red
+    '#dc2626', // 10 dark red
+];
+
+/**
+ * Colour for an RPE on the grey→green→yellow→red effort scale. Out-of-range values clamp to the
+ * nearest end so callers never get `undefined`.
+ */
+export function rpeColor(rpe: number): string {
+    const clamped = Math.min(Math.max(Math.round(rpe), RPE_MIN), RPE_MAX);
+    return RPE_COLORS[clamped - RPE_MIN];
+}
+
 /**
  * Normalizes a raw RPE (Rate of Perceived Exertion) input into a stored value.
  * RPE is optional, so anything blank, non-numeric, non-integer, or outside 1..10 becomes


### PR DESCRIPTION
Two UI changes to the log form.

## 1. RPE as a colored scale picker
Replaces the RPE number field with **10 colour-coded buttons** on a grey → green → yellow → red effort scale. Tapping the selected value again clears it (RPE stays optional).

- `model/rpe.ts` — pure `rpeColor(n)` + `RPE_VALUES`; one colour per 1..10, out-of-range clamps to the nearest end.
- `form/rpe-selector.tsx` — responsive button group (`flex-1` so all 10 fit on mobile), selected button ringed + scaled, others dimmed.
- History RPE badge now uses the same colour instead of plain `@N`.

## 2. Tighter mobile form
- Reduced the form's vertical gaps (`gap-y-8 → gap-y-3`, `pb-6 → pb-4`) and page padding on mobile (`p-10 → p-5`, `sm:` restores desktop).
- Moved **Exercise history** onto the Submit row as an **icon button** (`faClockRotateLeft`) instead of a separate full-width button below the form — saves a row.

## Tested (TDD)
`rpeColor` tests written first: a colour for every value, hex format, grey→red endpoints, out-of-range clamping.

`41 passed` in production mode; `tsc --noEmit` clean for both apps; **`nx build workout-log` succeeds** (full Next.js production build).

Visual bits (exact colours, spacing) are best eyeballed on the Vercel preview.