### PR TITLE
fix: heal spuriously-split sessions + tap a log's date for full date-time

### DIFF
--- a/apps/workout-log/src/app/history/workout-session.spec.ts
+++ b/apps/workout-log/src/app/history/workout-session.spec.ts
@@ -103,14 +103,38 @@ describe('groupWorkoutsIntoSessions', () => {
         expect(sessions[1].sessionId).toEqual("A");
     })
 
-    it('keeps two same-day sessions apart even when their logs are close in time', () => {
-        // Persisted ids are authoritative: these would merge under pure time-grouping, but must not.
-        const secondSession = row("2", new Date("2024-07-13T10:20:00"), {sessionId: "B"});
-        const firstSession = row("1", new Date("2024-07-13T10:00:00"), {sessionId: "A"});
+    it('heals a spurious split: neighbours with different ids but within the gap merge', () => {
+        // resolveSessionId only mints a new id after a >gap pause or a failed read of the previous
+        // set, so two sets 20 min apart carrying different ids can only be a single session that was
+        // wrongly split at write time. Time proximity must win here.
+        const secondSet = row("2", new Date("2024-07-13T10:20:00"), {sessionId: "B"});
+        const firstSet = row("1", new Date("2024-07-13T10:00:00"), {sessionId: "A"});
 
-        const sessions = groupWorkoutsIntoSessions([secondSession, firstSession]);
+        const sessions = groupWorkoutsIntoSessions([secondSet, firstSet]);
 
-        expect(sessions).toHaveLength(2);
+        expect(sessions).toHaveLength(1);
+        expect(sessions[0].workouts).toEqual([secondSet, firstSet]);
+    })
+
+    it('heals the real prod split (a 31-min bench session broken at a 7.5-min gap)', () => {
+        // Exact shape of the reported bug: one continuous session whose sets carry two different ids
+        // because a mid-session write got a fresh id. Every consecutive gap is a few minutes.
+        const sessionA = "64649f8d-a016-415c-b41f-1cd62f7bd395";
+        const sessionB = "7ded470d-ba50-4ad0-8316-21943d260b85";
+        const workouts = [
+            row("QYFTun", new Date(1784743631556), {sessionId: sessionB}),
+            row("qx1K9h", new Date(1784743356196), {sessionId: sessionB}),
+            row("oI13iu", new Date(1784743188424), {sessionId: sessionB}),
+            row("rzLgSq", new Date(1784742954833), {sessionId: sessionB}),
+            row("oCr4uV", new Date(1784742507438), {sessionId: sessionA}),
+            row("tDUX72", new Date(1784742156704), {sessionId: sessionA}),
+            row("KbvXzC", new Date(1784741776900), {sessionId: sessionA}),
+        ];
+
+        const sessions = groupWorkoutsIntoSessions(workouts);
+
+        expect(sessions).toHaveLength(1);
+        expect(sessions[0].workouts).toHaveLength(7);
     })
 
     it('falls back to time proximity for legacy logs without a sessionId', () => {
@@ -164,5 +188,19 @@ describe('countSessionsThisWeek', () => {
         ];
 
         expect(countSessionsThisWeek(workouts, now)).toEqual(1);
+    })
+
+    it('counts a spuriously-split session (two ids, minutes apart) once', () => {
+        // The real prod data: one Wed 2026-07-22 bench session broken into two ids at a 7.5-min gap.
+        // Week under test here: Monday 2026-07-20 → Sunday 2026-07-26.
+        const july22 = new Date("2026-07-24T12:00:00");
+        const workouts = [
+            row("QYFTun", new Date(1784743631556), {sessionId: "7ded470d"}),
+            row("rzLgSq", new Date(1784742954833), {sessionId: "7ded470d"}),
+            row("oCr4uV", new Date(1784742507438), {sessionId: "64649f8d"}),
+            row("KbvXzC", new Date(1784741776900), {sessionId: "64649f8d"}),
+        ];
+
+        expect(countSessionsThisWeek(workouts, july22)).toEqual(1);
     })
 })

--- a/apps/workout-log/src/app/history/workout-session.spec.ts
+++ b/apps/workout-log/src/app/history/workout-session.spec.ts
@@ -137,6 +137,41 @@ describe('groupWorkoutsIntoSessions', () => {
         expect(sessions[0].workouts).toHaveLength(7);
     })
 
+    it('heals a session fragmented into three different ids when every gap stays within the window', () => {
+        // A read can fail more than once in a session, minting a fresh id each time. As long as each
+        // consecutive gap is within the window the whole thing must still collapse to one session.
+        const workouts = [
+            row("5", new Date("2024-07-13T10:40:00"), {sessionId: "C"}),
+            row("4", new Date("2024-07-13T10:30:00"), {sessionId: "C"}),
+            row("3", new Date("2024-07-13T10:20:00"), {sessionId: "B"}),
+            row("2", new Date("2024-07-13T10:10:00"), {sessionId: "B"}),
+            row("1", new Date("2024-07-13T10:00:00"), {sessionId: "A"}),
+        ];
+
+        const sessions = groupWorkoutsIntoSessions(workouts);
+
+        expect(sessions).toHaveLength(1);
+        expect(sessions[0].workouts).toHaveLength(5);
+    })
+
+    it('merges different ids exactly at the gap boundary but splits one millisecond past it', () => {
+        // Guards the healing rule from over-reaching: two genuinely separate visits are always more
+        // than the gap apart, so the boundary is exactly where a spurious split stops being plausible.
+        const base = new Date("2024-07-13T10:00:00").valueOf();
+
+        const atBoundary = groupWorkoutsIntoSessions([
+            row("2", new Date(base + SESSION_MAX_GAP_IN_MS), {sessionId: "B"}),
+            row("1", new Date(base), {sessionId: "A"}),
+        ]);
+        expect(atBoundary).toHaveLength(1);
+
+        const pastBoundary = groupWorkoutsIntoSessions([
+            row("2", new Date(base + SESSION_MAX_GAP_IN_MS + 1), {sessionId: "B"}),
+            row("1", new Date(base), {sessionId: "A"}),
+        ]);
+        expect(pastBoundary).toHaveLength(2);
+    })
+
     it('falls back to time proximity for legacy logs without a sessionId', () => {
         const workouts = [
             row("4", new Date("2024-07-13T18:20:00")),

--- a/apps/workout-log/src/app/history/workout-session.ts
+++ b/apps/workout-log/src/app/history/workout-session.ts
@@ -40,8 +40,14 @@ export function resolveSessionId(
 }
 
 /**
- * Groups workout logs into sessions for display. When both neighbours carry a persisted `sessionId`
- * that id is authoritative; for legacy logs without one it falls back to time proximity.
+ * Groups workout logs into sessions for display. Two neighbours belong to the same session when they
+ * share a persisted `sessionId` OR they were logged within `maxGapInMs` of each other.
+ *
+ * The time-proximity fallback is not just for legacy logs: `resolveSessionId` only ever mints a *new*
+ * id when there was no readable previous set (a best-effort Firestore read can transiently return
+ * nothing) or when the real gap exceeds `maxGapInMs`. So two neighbours that carry *different* ids yet
+ * sit within the gap can only be a spuriously-split single session — merging them by time heals that.
+ * Genuinely separate gym visits are always more than `maxGapInMs` apart, so they still split.
  *
  * `workouts` is expected to be sorted most-recent-first (as returned by `getMostRecents`); the
  * returned sessions and the workouts inside them preserve that order.
@@ -84,8 +90,8 @@ export function countSessionsThisWeek(workouts: WorkoutRow[], now: Date = new Da
 }
 
 function belongToSameSession(a: WorkoutRow, b: WorkoutRow, maxGapInMs: number): boolean {
-    if (a.value.sessionId && b.value.sessionId) {
-        return a.value.sessionId === b.value.sessionId;
+    if (a.value.sessionId && b.value.sessionId && a.value.sessionId === b.value.sessionId) {
+        return true;
     }
     return Math.abs(a.value.date - b.value.date) <= maxGapInMs;
 }

--- a/apps/workout-log/src/app/history/workout-short-history.tsx
+++ b/apps/workout-log/src/app/history/workout-short-history.tsx
@@ -1,10 +1,23 @@
 import React from "react";
+import {Bounce, toast} from "react-toastify";
 import {WorkoutRow} from "../workout";
 import {RemoveWorkoutButton} from "./remove-workout-button";
-import {formatNarrowSmartly} from "../utils/date-utils";
+import {formatFullDateTime, formatNarrowSmartly} from "../utils/date-utils";
 import {groupWorkoutsIntoSessions} from "./workout-session";
 import {classifySessionSets} from "./set-intensity";
 import {rpeColor} from "../model/rpe";
+
+// The list shows a deliberately compact date; tapping it surfaces the exact date & time.
+function showFullDateTime(timestamp: number): void {
+    toast.info(formatFullDateTime(timestamp), {
+        position: "bottom-center",
+        autoClose: 5000,
+        closeOnClick: true,
+        pauseOnHover: true,
+        theme: "light",
+        transition: Bounce,
+    });
+}
 
 interface WorkoutHistoryProps {
     workoutList: WorkoutRow[],
@@ -44,9 +57,13 @@ export default function WorkoutShortHistory(props: WorkoutHistoryProps) {
                                             title={setIntensity.get(workout.id) === "warmup" ? "warm-up set" : undefined}>
                                             <div className="flex flex-row space-x-4 justify-between">
 
-                                                <div className="text-gray-500">
+                                                <button
+                                                    type="button"
+                                                    className="text-gray-500 hover:underline focus:underline cursor-pointer"
+                                                    title="Show full date & time"
+                                                    onClick={() => showFullDateTime(workout.value.date)}>
                                                     {formatNarrowSmartly(workout.value.date)}
-                                                </div>
+                                                </button>
                                                 <div className="inline-flex min-w-0">
                                                     {workout.value.exercise}
                                                 </div>

--- a/apps/workout-log/src/app/utils/date-utils.spec.tsx
+++ b/apps/workout-log/src/app/utils/date-utils.spec.tsx
@@ -1,4 +1,4 @@
-import {formatNarrowSmartly, getDateDiffInSecondsAndMinutes, startOfIsoWeek} from "./date-utils";
+import {formatFullDateTime, formatNarrowSmartly, getDateDiffInSecondsAndMinutes, startOfIsoWeek} from "./date-utils";
 import {describe, expect, it} from 'vitest'
 
 const US_LOCALE = new Intl.Locale('en-US');
@@ -55,6 +55,20 @@ describe('date utils tests', () => {
         expect(res).toEqual('03:00');
     })
 })
+describe('formatFullDateTime', () => {
+    it('includes weekday, full date and time (FR, 24h)', () => {
+        const res = formatFullDateTime(new Date("2024-07-13T14:05:09").valueOf(), FR_LOCALE);
+
+        expect(res).toEqual('sam. 13 juil. 2024, 14:05:09');
+    })
+
+    it('includes weekday, full date and time (US, 12h)', () => {
+        const res = formatFullDateTime(new Date("2024-07-13T14:05:09").valueOf(), US_LOCALE);
+
+        expect(res).toEqual('Sat, Jul 13, 2024, 02:05:09 PM');
+    })
+})
+
 describe('startOfIsoWeek', () => {
     it('returns the Monday for a mid-week day', () => {
         // 2024-07-10 is a Wednesday; its ISO week starts Monday 2024-07-08.

--- a/apps/workout-log/src/app/utils/date-utils.ts
+++ b/apps/workout-log/src/app/utils/date-utils.ts
@@ -14,6 +14,23 @@ export function formatNarrowSmartly(timestampToFormat: number, overrideDefaultLo
 }
 
 /**
+ * Full, human-readable date + time for a log — shown when the user taps a log's short date.
+ * `formatNarrowSmartly` deliberately hides most of this to stay compact, so this is the "see everything" view.
+ */
+export function formatFullDateTime(timestamp: number, overrideDefaultLocale?: Intl.Locale): string {
+    const locale = overrideDefaultLocale ? overrideDefaultLocale : 'default';
+    return new Date(timestamp).toLocaleString(locale, {
+        weekday: 'short',
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+    });
+}
+
+/**
  * Returns the start (00:00:00.000, local time) of the ISO week — i.e. the Monday — containing `date`.
  * Used to bound "this week" as Monday→Sunday for the weekly session counter.
  */


### PR DESCRIPTION
## 1. Session-grouping bug (the counter double-count)

**Symptom:** a single gym session showed up as two in the "last workouts" list and was counted twice by the weekly counter.

**Real cause (from the reported prod data):** the whole thing was one **31-minute** bench session, split at a **7.5-minute** gap — nowhere near the 3h threshold. The first set of the second batch was assigned a fresh `sessionId`:

| set | time | gap | sessionId |
|-----|------|-----|-----------|
| KbvXzC | 19:36:16 | — | `64649f8d` |
| tDUX72 | 19:42:36 | 6.3 min | `64649f8d` |
| oCr4uV | 19:48:27 | 5.8 min | `64649f8d` |
| rzLgSq | 19:55:54 | **7.5 min** | `7ded470d` ← new id |
| oI13iu … QYFTun | … | 2–5 min | `7ded470d` |

`add()` resolves the session by reading the previous set with `getMostRecents(db, userId, 1)`, and those Firestore helpers are **best-effort** — they swallow errors and return `[]` (documented gotcha in CLAUDE.md). When that read transiently returned nothing, `resolveSessionId` got `undefined` and minted a new id mid-session. Grouping then treated `sessionId` as *absolutely* authoritative, so the split could never heal.

**Fix:** two neighbours belong to the same session if they **share a `sessionId` OR were logged within the gap**. Since `resolveSessionId` only ever mints a new id after a >gap pause or a failed read, two neighbours with *different* ids that sit within the gap can only be a spurious split — safe to merge. Genuinely separate gym visits are always >gap apart, so they still split. Fixes both the history list and the weekly counter.

Tests: rewrote the old "keep close-in-time different-ids apart" case (it encoded the buggy behavior), added a regression test built from the exact prod timestamps, and a counter test asserting it now counts as one.

## 2. Tap a log's date → full date & time

The history list shows a deliberately compact date. Tapping it now surfaces the full weekday / date / time via a toast (same pattern the info tooltip already uses), backed by a new `formatFullDateTime` helper (unit-tested, FR + US locales).

## Verification
- **52/52 unit tests pass**, `tsc --noEmit` clean, `nx build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)