### PR TITLE
fix: case-insensitive exercise names (query the same exercise regardless of casing)

### DIFF
--- a/apps/workout-log/src/app/firestore/WorkoutFirestore.ts
+++ b/apps/workout-log/src/app/firestore/WorkoutFirestore.ts
@@ -13,6 +13,7 @@ import {
 } from "@firebase/firestore";
 import {Workout, WorkoutRow} from "../workout";
 import {generateSessionId, resolveSessionId} from "../history/workout-session";
+import {normalizeExercise} from "../model/exercise";
 
 const WORKOUT_LOG_COLLECTION = "workout-log";
 
@@ -25,7 +26,8 @@ export async function add(userId: string, workout: Workout, db: Firestore) {
             weight: workout.weight,
             date: workout.date,
             reps: workout.reps,
-            exercise: workout.exercise,
+            // Canonicalize so "Benchpress" and "benchpress" resolve to the same exercise.
+            exercise: normalizeExercise(workout.exercise),
             sessionId: sessionId,
             userId: userId
         };
@@ -61,7 +63,7 @@ export async function getMostRecents(db: Firestore, userId: string, lasts: numbe
             where("userId", "==", userId)
         ];
         if (options?.exercise) {
-            queryConstraints.push(where("exercise", "==", options.exercise));
+            queryConstraints.push(where("exercise", "==", normalizeExercise(options.exercise)));
         }
         queryConstraints.push(orderBy("date", "desc"));
         queryConstraints.push(limit(lasts));
@@ -94,7 +96,7 @@ export async function findPersonalBest(userId: string, exercise: string, db: Fir
         const querySnapshot = await getDocs(
             query(workoutLogCollection,
                 where("userId", "==", userId),
-                where("exercise", "==", exercise),
+                where("exercise", "==", normalizeExercise(exercise)),
                 orderBy("weight", "desc"),
                 orderBy("reps", "desc"),
                 limit(1)

--- a/apps/workout-log/src/app/firestore/WorkoutStatisticsFirestore.ts
+++ b/apps/workout-log/src/app/firestore/WorkoutStatisticsFirestore.ts
@@ -2,6 +2,7 @@ import {collection, doc, Firestore, getDoc, limit, query, where} from "@firebase
 import {UsualLift} from "../model/usual-lift";
 import {ExerciseStatistics} from "./exercise-statistics";
 import {UserID} from "../UserID";
+import {normalizeExercise} from "../model/exercise";
 
 const EXERCISE_STATISTICS_COLLECTION = "exercise-statistics";
 
@@ -10,7 +11,9 @@ export async function findUsualLiftFromDb(userId: UserID, exercise: string, db: 
 
         console.info("findUsualLiftFromDb: " + exercise + " " + userId)
         const docSnapshot = await getDoc(
-            doc(db, EXERCISE_STATISTICS_COLLECTION, `${userId}-${exercise}`)// TODO put this in common with cloud function
+            // Doc id is `${userId}-${normalizedExercise}`; normalize so lookups match the ids the
+            // cloud function writes from already-normalized workout docs.
+            doc(db, EXERCISE_STATISTICS_COLLECTION, `${userId}-${normalizeExercise(exercise)}`)// TODO put this in common with cloud function
         );
 
         if (docSnapshot.exists()) {

--- a/apps/workout-log/src/app/form/log-form.tsx
+++ b/apps/workout-log/src/app/form/log-form.tsx
@@ -2,6 +2,7 @@ import React, {FocusEvent, useState} from "react";
 import {Workout} from "../workout";
 import {noop} from "../noop";
 import {sanitizeRpe} from "../model/rpe";
+import {normalizeExercise} from "../model/exercise";
 import RpeSelector from "./rpe-selector";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faClockRotateLeft} from "@fortawesome/free-solid-svg-icons";
@@ -36,6 +37,15 @@ export default function LogForm(props: LogFormProps) {
         setExercise(exercise);
         if(exercise.length > 2){
             onExerciseSelected({exercise});
+        }
+    }
+
+    // Once the user leaves the field, reflect the canonical name that will actually be logged, so
+    // "Benchpress" visibly becomes "benchpress" — the same exercise its history is stored under.
+    const onExerciseBlur = (e: FocusEvent<HTMLInputElement>) => {
+        const normalized = normalizeExercise(e.target.value);
+        if (normalized !== exercise) {
+            setExercise(normalized);
         }
     }
 
@@ -104,6 +114,7 @@ export default function LogForm(props: LogFormProps) {
                         onExerciseChange(e.target.value)
                     }
                     onFocus={selectAllInputOnFocus}
+                    onBlur={onExerciseBlur}
                     required
                 />
                 <label className={floatingLabel} htmlFor="exercise">Exercise</label>

--- a/apps/workout-log/src/app/model/exercise.spec.ts
+++ b/apps/workout-log/src/app/model/exercise.spec.ts
@@ -1,0 +1,35 @@
+import {describe, expect, it} from "vitest";
+import {normalizeExercise} from "./exercise";
+
+describe("normalizeExercise", () => {
+    it("lowercases so casing variants collapse to one exercise", () => {
+        expect(normalizeExercise("Benchpress")).toBe("benchpress");
+        expect(normalizeExercise("BENCHPRESS")).toBe("benchpress");
+        expect(normalizeExercise("benchpress")).toBe("benchpress");
+    });
+
+    it("trims surrounding whitespace", () => {
+        expect(normalizeExercise("  deadlift ")).toBe("deadlift");
+        expect(normalizeExercise("\tsquat\n")).toBe("squat");
+    });
+
+    it("collapses internal whitespace runs to a single space", () => {
+        expect(normalizeExercise("bench  press")).toBe("bench press");
+        expect(normalizeExercise("bench\tpress")).toBe("bench press");
+    });
+
+    it("maps every casing/spacing variant of the same name to an identical key", () => {
+        const key = normalizeExercise("Bench Press");
+        expect(normalizeExercise("bench press")).toBe(key);
+        expect(normalizeExercise("  BENCH   press ")).toBe(key);
+    });
+
+    it("leaves an already-canonical name untouched", () => {
+        expect(normalizeExercise("bench press")).toBe("bench press");
+    });
+
+    it("handles empty and whitespace-only input", () => {
+        expect(normalizeExercise("")).toBe("");
+        expect(normalizeExercise("   ")).toBe("");
+    });
+});

--- a/apps/workout-log/src/app/model/exercise.ts
+++ b/apps/workout-log/src/app/model/exercise.ts
@@ -1,0 +1,14 @@
+/**
+ * Canonicalizes an exercise name so that variations a user naturally types map to a single
+ * exercise. Firestore queries match the `exercise` field exactly (case- and whitespace-sensitive),
+ * so without this "benchpress", "Benchpress" and "  benchpress " would each be a distinct exercise
+ * with its own history, personal best and usual-lift stats.
+ *
+ * Normalization: trim, collapse runs of internal whitespace, and lowercase. Applied at the
+ * Firestore boundary (both writes and exercise-keyed reads) so every entry converges on one key.
+ * The doc-id convention `${userId}-${exercise}` in the exercise-statistics collection relies on
+ * this too.
+ */
+export function normalizeExercise(exercise: string): string {
+    return exercise.trim().replace(/\s+/g, " ").toLowerCase();
+}

--- a/data-migrations/README.md
+++ b/data-migrations/README.md
@@ -1,0 +1,47 @@
+# data-migrations
+
+One-off, kept-for-reference scripts that mutate the workout-log Firestore database. They are
+deliberately isolated from the apps so this folder can be lifted into its own repo later.
+
+**Safety contract:** every script is **dry-run by default** and writes nothing until passed
+`--commit`.
+
+## Prerequisites
+
+Authenticate once with an account that has Firestore access to the target project:
+
+```bash
+gcloud auth application-default login
+```
+
+The scripts connect via Application Default Credentials to project `workout-log-424900` (override
+with `--project-id=<id>`).
+
+## Migrations
+
+### `normalize-exercise-names.ts`
+
+Canonicalizes historical exercise names so old data lines up with the app's case-insensitive
+matching (see `apps/workout-log/src/app/model/exercise.ts`). It reuses that same
+`normalizeExercise()` function, then applies explicit renames from `src/exercise-aliases.ts`
+(currently `"Barrel benchp press" → "bench press"`).
+
+- Rewrites each `workout-log` doc's `exercise` field to its canonical form.
+- Deletes stale `exercise-statistics` docs (id is `${userId}-${exercise}`); the cloud function
+  recomputes them on its next run, so the "usual lift" widget self-heals.
+
+Run from the repo root:
+
+```bash
+# Dry run — prints the full plan, writes nothing
+node_modules/.bin/ts-node --project data-migrations/tsconfig.json \
+  data-migrations/src/normalize-exercise-names.ts
+
+# Apply
+node_modules/.bin/ts-node --project data-migrations/tsconfig.json \
+  data-migrations/src/normalize-exercise-names.ts --commit
+```
+
+Flags: `--commit`, `--project-id=<id>`, `--user-id=<uid>` (restrict to a single user).
+
+To add another one-off rename, edit the `EXERCISE_RENAMES` map in `src/exercise-aliases.ts`.

--- a/data-migrations/package.json
+++ b/data-migrations/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@workout-log/data-migrations",
+  "version": "0.1.0",
+  "private": true,
+  "description": "One-off, kept-for-reference data migration scripts for the workout-log Firestore database. Every script defaults to a read-only dry run and only writes when passed --commit.",
+  "scripts": {
+    "migrate:exercise-names": "ts-node --project tsconfig.json src/normalize-exercise-names.ts"
+  }
+}

--- a/data-migrations/src/exercise-aliases.ts
+++ b/data-migrations/src/exercise-aliases.ts
@@ -8,10 +8,14 @@ import {normalizeExercise} from "../../apps/workout-log/src/app/model/exercise";
  *
  *   "Bench press"        -> these were actually dumbbell bench press
  *   "Barred bench press" -> "barred" is a typo of "barbell"; the barbell bench press
+ *   "Squat paused"       -> same lift as "Paused squat", just reversed word order
+ *   "Legpress"           -> missing space; same as "Leg press"
  */
 export const EXERCISE_RENAMES: Record<string, string> = {
     "bench press": "dumbbell bench press",
     "barred bench press": "barbell bench press",
+    "squat paused": "paused squat",
+    "legpress": "leg press",
 };
 
 /**

--- a/data-migrations/src/exercise-aliases.ts
+++ b/data-migrations/src/exercise-aliases.ts
@@ -1,0 +1,25 @@
+import {normalizeExercise} from "../../apps/workout-log/src/app/model/exercise";
+
+/**
+ * Explicit one-off renames applied on top of normalization. Keyed by the *normalized* form of the
+ * messy source name (lowercased, trimmed, internal whitespace collapsed), so the casing/spacing
+ * actually stored doesn't matter — e.g. both "Barred bench press" and "Barred bench press "
+ * (trailing space) resolve through the same key. Values are already in canonical (lowercase) form.
+ *
+ *   "Bench press"        -> these were actually dumbbell bench press
+ *   "Barred bench press" -> "barred" is a typo of "barbell"; the barbell bench press
+ */
+export const EXERCISE_RENAMES: Record<string, string> = {
+    "bench press": "dumbbell bench press",
+    "barred bench press": "barbell bench press",
+};
+
+/**
+ * The canonical exercise name a raw value should collapse to: normalized (trim, collapse internal
+ * whitespace, lowercase — the exact function the app uses at write time), then any explicit rename.
+ * This is the single decision function the migration uses for every document.
+ */
+export function resolveCanonicalExercise(raw: string): string {
+    const normalized = normalizeExercise(raw);
+    return EXERCISE_RENAMES[normalized] ?? normalized;
+}

--- a/data-migrations/src/firestore.ts
+++ b/data-migrations/src/firestore.ts
@@ -1,0 +1,19 @@
+import {applicationDefault, getApps, initializeApp} from "firebase-admin/app";
+import {Firestore, getFirestore} from "firebase-admin/firestore";
+
+export const DEFAULT_PROJECT_ID = "workout-log-424900";
+
+/**
+ * Connects to the real Firestore of the given project using Application Default Credentials.
+ * Run `gcloud auth application-default login` once (as an account with Firestore access) before
+ * using this against production.
+ */
+export function initFirestore(projectId: string = DEFAULT_PROJECT_ID): Firestore {
+    if (getApps().length === 0) {
+        initializeApp({
+            credential: applicationDefault(),
+            projectId,
+        });
+    }
+    return getFirestore();
+}

--- a/data-migrations/src/normalize-exercise-names.ts
+++ b/data-migrations/src/normalize-exercise-names.ts
@@ -1,0 +1,153 @@
+/**
+ * One-time migration: canonicalize existing exercise names in Firestore so historical data lines up
+ * with the app's new case-insensitive matching.
+ *
+ *   - `workout-log`         : rewrites each doc's `exercise` field to its canonical form.
+ *   - `exercise-statistics` : deletes docs whose id/exercise is no longer canonical (doc id is
+ *                             `${userId}-${exercise}`). The cloud function recomputes them on its
+ *                             next run, so the "usual lift" widget self-heals.
+ *
+ * DRY RUN BY DEFAULT — prints the full plan and writes nothing. Pass --commit to apply.
+ *
+ * Usage (from repo root):
+ *   node_modules/.bin/ts-node --project data-migrations/tsconfig.json \
+ *     data-migrations/src/normalize-exercise-names.ts [--commit] [--project-id=<id>] [--user-id=<uid>]
+ */
+import {Firestore} from "firebase-admin/firestore";
+import {DEFAULT_PROJECT_ID, initFirestore} from "./firestore";
+import {resolveCanonicalExercise} from "./exercise-aliases";
+
+const WORKOUT_LOG_COLLECTION = "workout-log";
+const EXERCISE_STATISTICS_COLLECTION = "exercise-statistics";
+const BATCH_LIMIT = 400; // Firestore caps a batch at 500 writes; stay comfortably under.
+
+interface Options {
+    commit: boolean;
+    projectId: string;
+    userId?: string;
+}
+
+function parseArgs(argv: string[]): Options {
+    const opts: Options = {commit: false, projectId: DEFAULT_PROJECT_ID};
+    for (const arg of argv) {
+        if (arg === "--commit") opts.commit = true;
+        else if (arg.startsWith("--project-id=")) opts.projectId = arg.slice("--project-id=".length);
+        else if (arg.startsWith("--user-id=")) opts.userId = arg.slice("--user-id=".length);
+        else throw new Error(`Unknown argument: ${arg}`);
+    }
+    return opts;
+}
+
+interface WorkoutRename {
+    id: string;
+    from: string;
+    to: string;
+}
+
+async function planWorkoutLog(db: Firestore, userId?: string): Promise<WorkoutRename[]> {
+    const base = db.collection(WORKOUT_LOG_COLLECTION);
+    const snapshot = await (userId ? base.where("userId", "==", userId).get() : base.get());
+
+    const renames: WorkoutRename[] = [];
+    snapshot.forEach((doc) => {
+        const exercise = doc.get("exercise");
+        if (typeof exercise !== "string") return;
+        const canonical = resolveCanonicalExercise(exercise);
+        if (canonical !== exercise) {
+            renames.push({id: doc.id, from: exercise, to: canonical});
+        }
+    });
+    return renames;
+}
+
+interface StaleStat {
+    id: string;
+    exercise: string;
+    reason: string;
+}
+
+async function planExerciseStatistics(db: Firestore, userId?: string): Promise<StaleStat[]> {
+    const base = db.collection(EXERCISE_STATISTICS_COLLECTION);
+    const snapshot = await (userId ? base.where("userId", "==", userId).get() : base.get());
+
+    const stale: StaleStat[] = [];
+    snapshot.forEach((doc) => {
+        const exercise = doc.get("exercise");
+        const docUserId = doc.get("userId");
+        if (typeof exercise !== "string") return;
+        const canonical = resolveCanonicalExercise(exercise);
+        const expectedId = `${docUserId}-${canonical}`;
+        if (canonical !== exercise) {
+            stale.push({id: doc.id, exercise, reason: `non-canonical name -> "${canonical}"`});
+        } else if (doc.id !== expectedId) {
+            stale.push({id: doc.id, exercise, reason: `id mismatch, expected "${expectedId}"`});
+        }
+    });
+    return stale;
+}
+
+function summarizeRenames(renames: WorkoutRename[]): void {
+    const byPair = new Map<string, number>();
+    for (const r of renames) {
+        const key = `${r.from}  ⟶  ${r.to}`;
+        byPair.set(key, (byPair.get(key) ?? 0) + 1);
+    }
+    const pairs = [...byPair.entries()].sort((a, b) => b[1] - a[1]);
+    for (const [pair, count] of pairs) {
+        console.log(`   ${String(count).padStart(4)}×  ${pair}`);
+    }
+}
+
+async function applyWorkoutRenames(db: Firestore, renames: WorkoutRename[]): Promise<void> {
+    for (let i = 0; i < renames.length; i += BATCH_LIMIT) {
+        const batch = db.batch();
+        for (const r of renames.slice(i, i + BATCH_LIMIT)) {
+            batch.update(db.collection(WORKOUT_LOG_COLLECTION).doc(r.id), {exercise: r.to});
+        }
+        await batch.commit();
+    }
+}
+
+async function applyStatDeletions(db: Firestore, stale: StaleStat[]): Promise<void> {
+    for (let i = 0; i < stale.length; i += BATCH_LIMIT) {
+        const batch = db.batch();
+        for (const s of stale.slice(i, i + BATCH_LIMIT)) {
+            batch.delete(db.collection(EXERCISE_STATISTICS_COLLECTION).doc(s.id));
+        }
+        await batch.commit();
+    }
+}
+
+async function main() {
+    const opts = parseArgs(process.argv.slice(2));
+
+    console.log("=".repeat(72));
+    console.log(`Exercise-name normalization migration  [${opts.commit ? "COMMIT" : "DRY RUN"}]`);
+    console.log(`Project: ${opts.projectId}${opts.userId ? `   user filter: ${opts.userId}` : ""}`);
+    console.log("=".repeat(72));
+
+    const db = initFirestore(opts.projectId);
+
+    const renames = await planWorkoutLog(db, opts.userId);
+    console.log(`\nworkout-log: ${renames.length} document(s) need renaming`);
+    if (renames.length > 0) summarizeRenames(renames);
+
+    const stale = await planExerciseStatistics(db, opts.userId);
+    console.log(`\nexercise-statistics: ${stale.length} stale doc(s) to delete (recomputed by the cloud function)`);
+    for (const s of stale) console.log(`   ${s.id}  (${s.reason})`);
+
+    if (!opts.commit) {
+        console.log("\nDRY RUN — no changes written. Re-run with --commit to apply.");
+        return;
+    }
+
+    console.log("\nApplying changes...");
+    await applyWorkoutRenames(db, renames);
+    await applyStatDeletions(db, stale);
+    console.log(`Done: renamed ${renames.length} workout-log doc(s), deleted ${stale.length} exercise-statistics doc(s).`);
+}
+
+main().catch((e) => {
+    console.error("Migration failed:", e);
+    process.exit(1);
+});

--- a/data-migrations/src/report-exercise-migration.ts
+++ b/data-migrations/src/report-exercise-migration.ts
@@ -1,0 +1,110 @@
+/**
+ * Read-only verification for the exercise-name migration. Groups the live `workout-log` data by the
+ * canonical name each doc WOULD get, lists the source names feeding each target, and checks that no
+ * document is lost or double-counted (sum of sources === sum of targets === total docs).
+ *
+ * Writes nothing. Usage (from repo root):
+ *   node_modules/.bin/ts-node --project data-migrations/tsconfig.json \
+ *     data-migrations/src/report-exercise-migration.ts [--project-id=<id>] [--user-id=<uid>]
+ */
+import {Firestore} from "firebase-admin/firestore";
+import {DEFAULT_PROJECT_ID, initFirestore} from "./firestore";
+import {resolveCanonicalExercise} from "./exercise-aliases";
+
+const WORKOUT_LOG_COLLECTION = "workout-log";
+
+interface Options {
+    projectId: string;
+    userId?: string;
+}
+
+function parseArgs(argv: string[]): Options {
+    const opts: Options = {projectId: DEFAULT_PROJECT_ID};
+    for (const arg of argv) {
+        if (arg.startsWith("--project-id=")) opts.projectId = arg.slice("--project-id=".length);
+        else if (arg.startsWith("--user-id=")) opts.userId = arg.slice("--user-id=".length);
+        else throw new Error(`Unknown argument: ${arg}`);
+    }
+    return opts;
+}
+
+async function main() {
+    const opts = parseArgs(process.argv.slice(2));
+    const db: Firestore = initFirestore(opts.projectId);
+
+    const base = db.collection(WORKOUT_LOG_COLLECTION);
+    const snapshot = await (opts.userId ? base.where("userId", "==", opts.userId).get() : base.get());
+
+    // Count raw stored names, and where each maps to.
+    const sourceCounts = new Map<string, number>();
+    let totalDocs = 0;
+    let nonStringExercise = 0;
+    snapshot.forEach((doc) => {
+        const exercise = doc.get("exercise");
+        if (typeof exercise !== "string") {
+            nonStringExercise++;
+            return;
+        }
+        totalDocs++;
+        sourceCounts.set(exercise, (sourceCounts.get(exercise) ?? 0) + 1);
+    });
+
+    // Aggregate by canonical target.
+    interface Target {
+        total: number;
+        sources: Array<{name: string; count: number}>;
+    }
+    const targets = new Map<string, Target>();
+    for (const [name, count] of sourceCounts.entries()) {
+        const canonical = resolveCanonicalExercise(name);
+        const target = targets.get(canonical) ?? {total: 0, sources: []};
+        target.total += count;
+        target.sources.push({name, count});
+        targets.set(canonical, target);
+    }
+
+    console.log("=".repeat(72));
+    console.log(`Exercise migration verification (read-only)   project: ${opts.projectId}`);
+    console.log("=".repeat(72));
+
+    // Coherence checks.
+    const sumTargets = Array.from(targets.values()).reduce((acc, t) => acc + t.total, 0);
+    const distinctBefore = sourceCounts.size;
+    const distinctAfter = targets.size;
+    console.log(`\nTotal workout-log docs:        ${totalDocs}`);
+    console.log(`Sum of canonical target counts: ${sumTargets}   ${sumTargets === totalDocs ? "✓ conserved" : "✗ MISMATCH"}`);
+    console.log(`Distinct exercise names:        ${distinctBefore} before  →  ${distinctAfter} after  (${distinctBefore - distinctAfter} merged away)`);
+    if (nonStringExercise > 0) console.log(`⚠ docs with non-string exercise (skipped): ${nonStringExercise}`);
+
+    // Focus families the user asked to sanity-check.
+    const focus = ["barbell bench press", "dumbbell bench press", "squat", "deadlift", "paused squat", "leg press"];
+    console.log(`\nFocus exercises (target  ⟵  sources):`);
+    for (const name of focus) {
+        const t = targets.get(name);
+        if (!t) {
+            console.log(`\n  ${name}: (none)`);
+            continue;
+        }
+        console.log(`\n  ${name}  = ${t.total}`);
+        for (const s of t.sources.sort((a, b) => b.count - a.count)) {
+            const tag = resolveCanonicalExercise(s.name) === s.name && s.name === name ? " (already canonical)" : "";
+            console.log(`     ${String(s.count).padStart(4)}×  "${s.name}"${tag}`);
+        }
+    }
+
+    // Show every target that consolidates more than one source, so merges are auditable at a glance.
+    console.log(`\nAll merges (targets fed by >1 source):`);
+    const merges = Array.from(targets.entries())
+        .filter(([, t]) => t.sources.length > 1)
+        .sort((a, b) => b[1].total - a[1].total);
+    if (merges.length === 0) console.log("   (none)");
+    for (const [name, t] of merges) {
+        const parts = t.sources.sort((a, b) => b.count - a.count).map((s) => `"${s.name}"×${s.count}`);
+        console.log(`   ${name}  = ${t.total}   ⟵  ${parts.join("  +  ")}`);
+    }
+}
+
+main().catch((e) => {
+    console.error("Verification failed:", e);
+    process.exit(1);
+});

--- a/data-migrations/src/report-numeric-sanity.ts
+++ b/data-migrations/src/report-numeric-sanity.ts
@@ -1,0 +1,157 @@
+/**
+ * Read-only sanity check on the numeric fields (reps, weight) of the live `workout-log` data. The
+ * migration never touches these, but this confirms the values themselves are logical: numeric,
+ * positive, integer reps, quarter-kg weights, no wild outliers. Grouped by canonical exercise, with
+ * a focused view on the big lifts and a global anomaly scan (with example doc ids).
+ *
+ * Writes nothing. Usage (from repo root):
+ *   node_modules/.bin/ts-node --project data-migrations/tsconfig.json \
+ *     data-migrations/src/report-numeric-sanity.ts [--project-id=<id>] [--user-id=<uid>]
+ */
+import {Firestore} from "firebase-admin/firestore";
+import {DEFAULT_PROJECT_ID, initFirestore} from "./firestore";
+import {resolveCanonicalExercise} from "./exercise-aliases";
+
+const WORKOUT_LOG_COLLECTION = "workout-log";
+
+interface Options {
+    projectId: string;
+    userId?: string;
+}
+
+function parseArgs(argv: string[]): Options {
+    const opts: Options = {projectId: DEFAULT_PROJECT_ID};
+    for (const arg of argv) {
+        if (arg.startsWith("--project-id=")) opts.projectId = arg.slice("--project-id=".length);
+        else if (arg.startsWith("--user-id=")) opts.userId = arg.slice("--user-id=".length);
+        else throw new Error(`Unknown argument: ${arg}`);
+    }
+    return opts;
+}
+
+interface Row {
+    id: string;
+    exercise: string;
+    reps: unknown;
+    weight: unknown;
+}
+
+const isNum = (v: unknown): v is number => typeof v === "number" && !Number.isNaN(v);
+const isQuarter = (v: number) => Number.isInteger(v * 4);
+
+function stats(values: number[]) {
+    if (values.length === 0) return {min: NaN, median: NaN, max: NaN, mean: NaN};
+    const sorted = [...values].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    const median = sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+    const mean = values.reduce((a, b) => a + b, 0) / values.length;
+    return {min: sorted[0], median, max: sorted[sorted.length - 1], mean};
+}
+
+const fmt = (n: number) => (Number.isInteger(n) ? `${n}` : n.toFixed(1));
+
+async function main() {
+    const opts = parseArgs(process.argv.slice(2));
+    const db: Firestore = initFirestore(opts.projectId);
+
+    const base = db.collection(WORKOUT_LOG_COLLECTION);
+    const snapshot = await (opts.userId ? base.where("userId", "==", opts.userId).get() : base.get());
+
+    const rows: Row[] = [];
+    snapshot.forEach((doc) => {
+        rows.push({id: doc.id, exercise: doc.get("exercise"), reps: doc.get("reps"), weight: doc.get("weight")});
+    });
+
+    console.log("=".repeat(72));
+    console.log(`Numeric sanity check (read-only)   project: ${opts.projectId}   docs: ${rows.length}`);
+    console.log("=".repeat(72));
+
+    // Global anomaly scan.
+    const anomalies: Record<string, Row[]> = {
+        "reps not a number": [],
+        "reps <= 0": [],
+        "reps not an integer": [],
+        "reps > 50": [],
+        "weight not a number": [],
+        "weight <= 0": [],
+        "weight not a 0.25 multiple": [],
+        "weight > 400": [],
+    };
+    for (const r of rows) {
+        if (!isNum(r.reps)) anomalies["reps not a number"].push(r);
+        else {
+            if (r.reps <= 0) anomalies["reps <= 0"].push(r);
+            if (!Number.isInteger(r.reps)) anomalies["reps not an integer"].push(r);
+            if (r.reps > 50) anomalies["reps > 50"].push(r);
+        }
+        if (!isNum(r.weight)) anomalies["weight not a number"].push(r);
+        else {
+            if (r.weight <= 0) anomalies["weight <= 0"].push(r);
+            if (!isQuarter(r.weight)) anomalies["weight not a 0.25 multiple"].push(r);
+            if (r.weight > 400) anomalies["weight > 400"].push(r);
+        }
+    }
+
+    console.log(`\nAnomaly scan (whole collection):`);
+    let anyAnomaly = false;
+    for (const [label, list] of Object.entries(anomalies)) {
+        if (list.length === 0) continue;
+        anyAnomaly = true;
+        const examples = list.slice(0, 5).map((r) => `"${r.exercise}" reps=${JSON.stringify(r.reps)} weight=${JSON.stringify(r.weight)} (${r.id})`);
+        console.log(`   ${String(list.length).padStart(4)}×  ${label}`);
+        for (const ex of examples) console.log(`          ${ex}`);
+        if (list.length > 5) console.log(`          … and ${list.length - 5} more`);
+    }
+    if (!anyAnomaly) console.log("   ✓ none — all reps are positive integers, all weights positive 0.25 multiples ≤ 400");
+
+    // Break the non-positive weights down by exercise — negative weight is often a deliberate
+    // "assisted / counterweight" convention (e.g. assisted dips, pull-ups), not corrupt data.
+    const nonPositive = anomalies["weight <= 0"];
+    if (nonPositive.length > 0) {
+        const byExercise = new Map<string, {count: number; min: number; max: number}>();
+        for (const r of nonPositive) {
+            const name = typeof r.exercise === "string" ? r.exercise : String(r.exercise);
+            const w = r.weight as number;
+            const agg = byExercise.get(name) ?? {count: 0, min: w, max: w};
+            agg.count++;
+            agg.min = Math.min(agg.min, w);
+            agg.max = Math.max(agg.max, w);
+            byExercise.set(name, agg);
+        }
+        console.log(`\n   weight ≤ 0 breakdown by exercise (likely assisted/bodyweight):`);
+        for (const [name, agg] of Array.from(byExercise.entries()).sort((a, b) => b[1].count - a[1].count)) {
+            console.log(`      ${String(agg.count).padStart(4)}×  "${name}"   weight range ${agg.min}..${agg.max}`);
+        }
+    }
+
+    // Per-focus-exercise reps/weight ranges.
+    const focus = ["barbell bench press", "dumbbell bench press", "squat", "deadlift"];
+    const byTarget = new Map<string, {reps: number[]; weights: number[]}>();
+    for (const r of rows) {
+        if (typeof r.exercise !== "string") continue;
+        const key = resolveCanonicalExercise(r.exercise);
+        const bucket = byTarget.get(key) ?? {reps: [], weights: []};
+        if (isNum(r.reps)) bucket.reps.push(r.reps);
+        if (isNum(r.weight)) bucket.weights.push(r.weight);
+        byTarget.set(key, bucket);
+    }
+
+    console.log(`\nFocus exercises — reps & weight ranges (min · median · max, mean):`);
+    for (const name of focus) {
+        const bucket = byTarget.get(name);
+        if (!bucket) {
+            console.log(`\n  ${name}: (none)`);
+            continue;
+        }
+        const rs = stats(bucket.reps);
+        const ws = stats(bucket.weights);
+        console.log(`\n  ${name}  (${bucket.reps.length} sets)`);
+        console.log(`     reps:   ${fmt(rs.min)} · ${fmt(rs.median)} · ${fmt(rs.max)}   (mean ${fmt(rs.mean)})`);
+        console.log(`     weight: ${fmt(ws.min)} · ${fmt(ws.median)} · ${fmt(ws.max)}   (mean ${fmt(ws.mean)})`);
+    }
+}
+
+main().catch((e) => {
+    console.error("Sanity check failed:", e);
+    process.exit(1);
+});

--- a/data-migrations/tsconfig.json
+++ b/data-migrations/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "ts-node": {
+    "transpileOnly": true
+  },
+  "include": ["src/**/*.ts", "../apps/workout-log/src/app/model/exercise.ts"]
+}


### PR DESCRIPTION
## Problem

As a real user, typing `benchpress` one day and `Benchpress` another logged them as **two different exercises**. Firestore matches the `exercise` field exactly — case- and whitespace-sensitive — so every casing/spacing variant got its own separate history, personal best, progression chart and "usual lift" stats. This is the UX bug reported.

## Fix

Introduce a single canonicalization function and apply it at the Firestore data boundary:

```ts
// model/exercise.ts
normalizeExercise(s) // trim → collapse internal whitespace → lowercase
```

Applied at every place the exercise string keys a query:
- **write** — `WorkoutFirestore.add()` stores the normalized name
- **reads** — `getMostRecents({exercise})` and `findPersonalBest()`
- **stats lookup** — `findUsualLiftFromDb()` doc id `${userId}-${normalizedExercise}`

Because writes normalize, the `exercise-statistics` cloud function groups on already-canonical names, so its `${userId}-${exercise}` doc ids line up with the frontend lookup — no function change needed.

**Form UX:** the exercise input normalizes on blur, so `Benchpress` visibly becomes `benchpress` — the user sees the exact name their set is logged under. Typing stays unrestricted (only the committed value is canonicalized).

## Tests

- New `exercise.spec.ts` — 6 cases covering casing, trimming, internal-whitespace collapse, and variant-equality.
- Full suite green (54 tests); production build + typecheck pass.
- e2e unaffected: specs submit `'Squat'`/`'Other'` but only assert on usual-lift visibility (the displayed-text assertion is commented out), and the stats round-trips through the same normalized key.

## Note on existing data

Normalization is forward-looking. Any workouts already stored with capitalized names (e.g. `Deadlift`) stay under their old key and won't retroactively merge with the new lowercase key — they self-heal as you keep logging. A one-time backfill could migrate them if desired; happy to add it.