### PR TITLE
feat: exercise catalog + smart autocomplete (variant suggestions)

### DIFF
--- a/apps/workout-log/src/app/form/exercise-combobox.spec.tsx
+++ b/apps/workout-log/src/app/form/exercise-combobox.spec.tsx
@@ -1,0 +1,66 @@
+import {afterEach, describe, expect, it, vi} from "vitest";
+import React, {useState} from "react";
+import {cleanup, fireEvent, render, screen, within} from "@testing-library/react";
+import ExerciseCombobox from "./exercise-combobox";
+
+afterEach(() => cleanup());
+
+// Controlled wrapper mirroring how LogForm drives the combobox, so typing updates `value`.
+function Harness(props: {onCommit?: (v: string) => void; knownExercises?: {name: string; count: number}[]}) {
+    const [value, setValue] = useState("");
+    return (
+        <ExerciseCombobox
+            value={value}
+            onChange={setValue}
+            onCommit={props.onCommit}
+            knownExercises={props.knownExercises}
+        />
+    );
+}
+
+const type = (text: string) => {
+    const input = screen.getByRole("combobox");
+    fireEvent.focus(input);
+    fireEvent.change(input, {target: {value: text}});
+    return input;
+};
+
+describe("ExerciseCombobox", () => {
+    it("token-matches across families as you type", () => {
+        render(<Harness/>);
+        type("paused");
+        const options = screen.getAllByRole("option").map((o) => o.textContent);
+        expect(options.join("|")).toContain("paused squat");
+        expect(options.join("|")).toContain("paused bench press");
+    });
+
+    it("commits the canonical name when a suggestion is clicked", () => {
+        const onCommit = vi.fn();
+        render(<Harness onCommit={onCommit}/>);
+        type("front sq");
+        fireEvent.mouseDown(screen.getByText("front squat"));
+        expect(onCommit).toHaveBeenCalledWith("front squat");
+    });
+
+    it("always offers a 'log as new' row for a custom name", () => {
+        render(<Harness/>);
+        type("zercher squat hold");
+        expect(screen.getByText(/log as new/i)).toBeDefined();
+    });
+
+    it("marks a logged exercise with its count", () => {
+        render(<Harness knownExercises={[{name: "hack squat", count: 9}]}/>);
+        type("hack");
+        const option = screen.getByText("hack squat").closest("li")!;
+        expect(within(option).getByText(/logged 9×/)).toBeDefined();
+    });
+
+    it("selects the active option with keyboard (ArrowDown + Enter)", () => {
+        const onCommit = vi.fn();
+        render(<Harness onCommit={onCommit}/>);
+        const input = type("squat");
+        fireEvent.keyDown(input, {key: "ArrowDown"});
+        fireEvent.keyDown(input, {key: "Enter"});
+        expect(onCommit).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/workout-log/src/app/form/exercise-combobox.tsx
+++ b/apps/workout-log/src/app/form/exercise-combobox.tsx
@@ -1,0 +1,181 @@
+import React, {useEffect, useMemo, useRef, useState} from "react";
+import {normalizeExercise} from "../model/exercise";
+import {ExerciseSuggestion, KnownExercise, searchExercises} from "../model/exercise-suggestions";
+
+interface ExerciseComboboxProps {
+    value: string;
+    /** Fires on every keystroke with the raw typed value. */
+    onChange: (value: string) => void;
+    /** Fires when a value is committed (suggestion picked or field left) with the canonical name. */
+    onCommit?: (value: string) => void;
+    /** The user's already-logged exercises (name + count), merged into the suggestions. */
+    knownExercises?: KnownExercise[];
+    id?: string;
+    inputClassName?: string;
+    labelClassName?: string;
+    label?: string;
+}
+
+/**
+ * Exercise input with a custom suggestion dropdown. Suggestions come from the shipped catalog merged
+ * with the user's logged history (see exercise-suggestions.ts), token-matched and ranked so typing
+ * "paused" surfaces every paused variant and "squat" the whole family. A "log as typed" row keeps
+ * free-form entry one tap away — the user is never forced onto a catalog value.
+ */
+export default function ExerciseCombobox(props: ExerciseComboboxProps) {
+    const {
+        value,
+        onChange,
+        onCommit,
+        knownExercises = [],
+        id = "exercise",
+        inputClassName,
+        labelClassName,
+        label = "Exercise",
+    } = props;
+
+    const [isOpen, setIsOpen] = useState(false);
+    const [activeIndex, setActiveIndex] = useState(-1);
+    const containerRef = useRef<HTMLDivElement>(null);
+    const blurTimeout = useRef<ReturnType<typeof setTimeout>>();
+
+    const suggestions = useMemo(
+        () => searchExercises(value, knownExercises),
+        [value, knownExercises],
+    );
+
+    // Offer the raw typed value as a custom option unless it already equals a listed suggestion.
+    const normalizedTyped = normalizeExercise(value);
+    const showCustomOption =
+        normalizedTyped.length > 0 &&
+        !suggestions.some((s) => s.name === normalizedTyped);
+
+    // Flat list of selectable rows: suggestions, then the optional custom row.
+    const rows: Array<{name: string; suggestion?: ExerciseSuggestion; custom?: boolean}> = [
+        ...suggestions.map((suggestion) => ({name: suggestion.name, suggestion})),
+        ...(showCustomOption ? [{name: normalizedTyped, custom: true}] : []),
+    ];
+
+    useEffect(() => () => clearTimeout(blurTimeout.current), []);
+
+    const commit = (name: string) => {
+        onChange(name);
+        onCommit?.(name);
+        setIsOpen(false);
+        setActiveIndex(-1);
+    };
+
+    const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (!isOpen && (e.key === "ArrowDown" || e.key === "ArrowUp")) {
+            setIsOpen(true);
+            return;
+        }
+        if (e.key === "ArrowDown") {
+            e.preventDefault();
+            setActiveIndex((i) => Math.min(i + 1, rows.length - 1));
+        } else if (e.key === "ArrowUp") {
+            e.preventDefault();
+            setActiveIndex((i) => Math.max(i - 1, 0));
+        } else if (e.key === "Enter") {
+            if (isOpen && activeIndex >= 0 && rows[activeIndex]) {
+                e.preventDefault();
+                commit(rows[activeIndex].name);
+            }
+        } else if (e.key === "Escape") {
+            setIsOpen(false);
+            setActiveIndex(-1);
+        }
+    };
+
+    const onBlur = () => {
+        // Delay so a click on a suggestion registers before we close and normalize.
+        blurTimeout.current = setTimeout(() => {
+            setIsOpen(false);
+            setActiveIndex(-1);
+            const normalized = normalizeExercise(value);
+            if (normalized !== value) onChange(normalized);
+            onCommit?.(normalized);
+        }, 120);
+    };
+
+    return (
+        <div className="relative" ref={containerRef}>
+            <input
+                type="text"
+                name={id}
+                id={id}
+                role="combobox"
+                aria-expanded={isOpen}
+                aria-controls={`${id}-listbox`}
+                aria-autocomplete="list"
+                aria-activedescendant={activeIndex >= 0 ? `${id}-option-${activeIndex}` : undefined}
+                autoComplete="off"
+                placeholder=" "
+                className={inputClassName}
+                value={value}
+                onChange={(e) => {
+                    onChange(e.target.value);
+                    setIsOpen(true);
+                    setActiveIndex(-1);
+                }}
+                onFocus={(e) => {
+                    clearTimeout(blurTimeout.current);
+                    e.target.select();
+                    setIsOpen(true);
+                }}
+                onBlur={onBlur}
+                onKeyDown={onKeyDown}
+                required
+            />
+            <label className={labelClassName} htmlFor={id}>{label}</label>
+
+            {isOpen && rows.length > 0 && (
+                <ul
+                    id={`${id}-listbox`}
+                    role="listbox"
+                    className="absolute z-20 mt-1 max-h-64 w-full overflow-auto rounded-md border border-gray-200 bg-white py-1 text-base shadow-lg"
+                >
+                    {rows.map((row, index) => (
+                        <li
+                            key={`${row.custom ? "custom:" : ""}${row.name}`}
+                            id={`${id}-option-${index}`}
+                            role="option"
+                            aria-selected={index === activeIndex}
+                            // onMouseDown (not onClick) so it fires before the input's blur closes the list.
+                            onMouseDown={(e) => {
+                                e.preventDefault();
+                                commit(row.name);
+                            }}
+                            onMouseEnter={() => setActiveIndex(index)}
+                            className={`flex cursor-pointer items-center justify-between gap-2 px-3 py-2 ${
+                                index === activeIndex ? "bg-main/10" : ""
+                            }`}
+                        >
+                            {row.custom ? (
+                                <span className="text-gray-600">
+                                    + Log <span className="font-medium text-gray-900">&ldquo;{row.name}&rdquo;</span> as new
+                                </span>
+                            ) : (
+                                <>
+                                    <span className="flex items-center gap-1.5 truncate">
+                                        {row.suggestion?.isDefault && (
+                                            <span className="text-amber-500" aria-hidden="true">★</span>
+                                        )}
+                                        <span className="truncate">{row.name}</span>
+                                    </span>
+                                    <span className="shrink-0 text-xs text-gray-400">
+                                        {row.suggestion && row.suggestion.loggedCount > 0
+                                            ? `logged ${row.suggestion.loggedCount}×`
+                                            : row.suggestion?.isDefault
+                                                ? "default"
+                                                : ""}
+                                    </span>
+                                </>
+                            )}
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+}

--- a/apps/workout-log/src/app/form/log-form.tsx
+++ b/apps/workout-log/src/app/form/log-form.tsx
@@ -2,8 +2,9 @@ import React, {FocusEvent, useState} from "react";
 import {Workout} from "../workout";
 import {noop} from "../noop";
 import {sanitizeRpe} from "../model/rpe";
-import {normalizeExercise} from "../model/exercise";
+import {KnownExercise} from "../model/exercise-suggestions";
 import RpeSelector from "./rpe-selector";
+import ExerciseCombobox from "./exercise-combobox";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faClockRotateLeft} from "@fortawesome/free-solid-svg-icons";
 
@@ -13,6 +14,7 @@ interface LogFormProps {
     lastWorkoutInput: Workout | undefined;
     onShowExerciseHistory?: () => void;
     canShowExerciseHistory?: boolean;
+    knownExercises?: KnownExercise[];
 }
 
 export default function LogForm(props: LogFormProps) {
@@ -22,6 +24,7 @@ export default function LogForm(props: LogFormProps) {
         lastWorkoutInput,
         onShowExerciseHistory = noop,
         canShowExerciseHistory = false,
+        knownExercises = [],
     } = props;
 
     const [exercise, setExercise] = useState(lastWorkoutInput ? lastWorkoutInput.exercise : "deadlift");
@@ -40,13 +43,11 @@ export default function LogForm(props: LogFormProps) {
         }
     }
 
-    // Once the user leaves the field, reflect the canonical name that will actually be logged, so
-    // "Benchpress" visibly becomes "benchpress" — the same exercise its history is stored under.
-    const onExerciseBlur = (e: FocusEvent<HTMLInputElement>) => {
-        const normalized = normalizeExercise(e.target.value);
-        if (normalized !== exercise) {
-            setExercise(normalized);
-        }
+    // Fired when the user picks a suggestion or leaves the field: the combobox hands back the
+    // canonical name it will be logged under, so refresh the stats/history for that exact exercise.
+    const onExerciseCommit = (exercise: string) => {
+        setExercise(exercise);
+        onExerciseSelected({exercise});
     }
 
     const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -101,29 +102,15 @@ export default function LogForm(props: LogFormProps) {
         >
             {error && <div style={{color: 'red'}}>{error}</div>}
 
-            <div className="form-element relative mt-2">
-                <input
-                    type="text"
-                    name="exercise"
-                    id="exercise"
-                    list="defaultExercices"
-                    placeholder=" "
-                    className={floatingInput}
+            <div className="form-element mt-2">
+                <ExerciseCombobox
                     value={exercise}
-                    onChange={(e) =>
-                        onExerciseChange(e.target.value)
-                    }
-                    onFocus={selectAllInputOnFocus}
-                    onBlur={onExerciseBlur}
-                    required
+                    onChange={onExerciseChange}
+                    onCommit={onExerciseCommit}
+                    knownExercises={knownExercises}
+                    inputClassName={floatingInput}
+                    labelClassName={floatingLabel}
                 />
-                <label className={floatingLabel} htmlFor="exercise">Exercise</label>
-                <datalist id="defaultExercices">
-                    <option value="deadlift"></option>
-                    <option value="squat"></option>
-                    <option value="bench press"></option>
-                    <option value="biceps curl"></option>
-                </datalist>
             </div>
             <div className="flex flex-row gap-3">
                 <div className="form-element relative flex-1">

--- a/apps/workout-log/src/app/home.tsx
+++ b/apps/workout-log/src/app/home.tsx
@@ -2,7 +2,7 @@
 
 import LogForm from "./form/log-form";
 import {Workout, WorkoutRow} from "./workout";
-import React, {useEffect, useRef, useState} from "react";
+import React, {useEffect, useMemo, useRef, useState} from "react";
 import WorkoutShortHistory from "./history/workout-short-history";
 
 import {add, deleteOne, findPersonalBest, getMostRecents} from "./firestore/WorkoutFirestore";
@@ -83,6 +83,17 @@ export default function Home(props: HomeProps) {
     const [bestWorkoutPerformance, setBestWorkoutPerformance] = useState<WorkoutRow | undefined>(undefined);
     const [usualLift, setUsualLift] = useState<UsualLift | undefined>(undefined);
 
+    // Distinct exercises the user has logged (within the fetched window), with counts, so the log
+    // form can suggest and rank the exercises they actually use alongside the shipped catalog.
+    const knownExercises = useMemo(() => {
+        const counts = new Map<string, number>();
+        for (const row of workoutRecentHistory) {
+            const name = row.value.exercise;
+            counts.set(name, (counts.get(name) ?? 0) + 1);
+        }
+        return Array.from(counts.entries()).map(([name, count]) => ({name, count}));
+    }, [workoutRecentHistory]);
+
     const findBestWorkoutPerformance = async (exercice: string) => {
         setBestWorkoutPerformance(await findPersonalBest(userID, exercice, db));
     }
@@ -137,6 +148,7 @@ export default function Home(props: HomeProps) {
                             <LogForm onWorkoutLog={onWorkoutLog} onExerciseSelected={onExerciseSelected}
                                      lastWorkoutInput={getLastWorkoutInputInLocalStorage()}
                                      canShowExerciseHistory={!!currentSelectedExercise}
+                                     knownExercises={knownExercises}
                                      onShowExerciseHistory={() => setDisplayWorkoutHistoryPage(true)}>
                             </LogForm>
                         </div>

--- a/apps/workout-log/src/app/model/exercise-catalog.ts
+++ b/apps/workout-log/src/app/model/exercise-catalog.ts
@@ -1,0 +1,115 @@
+/**
+ * Curated catalog of exercises grouped into families of variants. It ships with the app so a brand
+ * new user (or a user who hasn't logged a given variant yet) still gets good suggestions; the user's
+ * own logged exercises are merged on top at search time (see exercise-suggestions.ts).
+ *
+ * Conventions:
+ *  - Every name is already in canonical form (lowercase, single-spaced) — the same form the app
+ *    stores via normalizeExercise(). Keep it that way so suggestions map straight onto stored data.
+ *  - variants[0] is the family DEFAULT (the one surfaced first / starred).
+ *  - `family` is extra searchable text: typing "bench" matches the whole "bench press" family, so
+ *    every variant shows up even though the token isn't in, say, "dumbbell bench press" verbatim.
+ *
+ * To add or rename a variant, edit this list — it is the single source of truth for suggestions.
+ */
+export interface ExerciseFamily {
+    /** Canonical family label, also used as searchable text (e.g. "bench press"). */
+    family: string;
+    /** Canonical variant names in priority order; variants[0] is the family default. */
+    variants: string[];
+}
+
+export const EXERCISE_CATALOG: ExerciseFamily[] = [
+    {
+        family: "bench press",
+        variants: [
+            "barbell bench press",
+            "dumbbell bench press",
+            "machine bench press",
+            "incline barbell bench press",
+            "incline dumbbell bench press",
+            "paused bench press",
+            "close grip bench press",
+        ],
+    },
+    {
+        family: "squat",
+        variants: [
+            "squat",
+            "front squat",
+            "paused squat",
+            "hack squat",
+            "box squat",
+            "goblet squat",
+        ],
+    },
+    {
+        family: "deadlift",
+        variants: [
+            "deadlift",
+            "romanian deadlift",
+            "snatch deadlift",
+            "trap bar deadlift",
+            "sumo deadlift",
+        ],
+    },
+    {
+        family: "overhead press",
+        variants: [
+            "overhead press",
+            "military press",
+            "seated dumbbell press",
+            "arnold press",
+        ],
+    },
+    {
+        family: "row",
+        variants: [
+            "barbell row",
+            "low row",
+            "seated cable row",
+            "one-arm dumbbell row",
+            "t-bar row",
+        ],
+    },
+    {
+        family: "lat pulldown",
+        variants: [
+            "lat pulldown",
+            "close grip lat pulldown",
+            "wide grip lat pulldown",
+        ],
+    },
+    {
+        family: "chest press",
+        variants: [
+            "chest press",
+            "pectoral machine",
+            "cable fly",
+        ],
+    },
+    {
+        family: "leg press",
+        variants: [
+            "leg press",
+            "leg extension",
+            "leg curl",
+        ],
+    },
+    {
+        family: "curl",
+        variants: [
+            "biceps curl",
+            "hammer curl",
+            "preacher curl",
+        ],
+    },
+    {
+        family: "triceps",
+        variants: [
+            "triceps pushdown",
+            "skullcrusher",
+            "dips",
+        ],
+    },
+];

--- a/apps/workout-log/src/app/model/exercise-suggestions.spec.ts
+++ b/apps/workout-log/src/app/model/exercise-suggestions.spec.ts
@@ -1,0 +1,73 @@
+import {describe, expect, it} from "vitest";
+import {searchExercises} from "./exercise-suggestions";
+import {ExerciseFamily} from "./exercise-catalog";
+
+const CATALOG: ExerciseFamily[] = [
+    {family: "bench press", variants: ["barbell bench press", "dumbbell bench press", "paused bench press"]},
+    {family: "squat", variants: ["squat", "front squat", "paused squat", "hack squat"]},
+];
+
+const names = (query: string, history = [] as {name: string; count: number}[]) =>
+    searchExercises(query, history, CATALOG).map((s) => s.name);
+
+describe("searchExercises", () => {
+    it("token-matches across families: 'paused' surfaces every paused variant", () => {
+        expect(names("paused")).toEqual(
+            expect.arrayContaining(["paused bench press", "paused squat"]),
+        );
+        // and nothing without 'paused'
+        expect(names("paused")).not.toEqual(expect.arrayContaining(["front squat", "barbell bench press"]));
+    });
+
+    it("matches a whole family by the family word even when the token isn't in the variant name", () => {
+        // "bench" is not literally in "dumbbell bench press"? it is — use squat family word instead:
+        expect(names("squat")).toEqual(
+            expect.arrayContaining(["squat", "front squat", "paused squat", "hack squat"]),
+        );
+    });
+
+    it("ranks an exact match first", () => {
+        expect(names("front squat")[0]).toBe("front squat");
+    });
+
+    it("ranks prefix matches ahead of mid-string matches", () => {
+        const result = names("squat");
+        expect(result.indexOf("squat")).toBeLessThan(result.indexOf("front squat"));
+    });
+
+    it("heavily favors already-logged exercises, ordered by count", () => {
+        const history = [
+            {name: "hack squat", count: 30},
+            {name: "front squat", count: 5},
+        ];
+        const result = names("squat", history);
+        // both logged ones come before the never-logged "paused squat"
+        expect(result.indexOf("hack squat")).toBeLessThan(result.indexOf("paused squat"));
+        expect(result.indexOf("front squat")).toBeLessThan(result.indexOf("paused squat"));
+        // higher count first among logged
+        expect(result.indexOf("hack squat")).toBeLessThan(result.indexOf("front squat"));
+    });
+
+    it("surfaces logged exercises that aren't in the catalog", () => {
+        const history = [{name: "Calf raise", count: 12}];
+        expect(names("calf", history)).toContain("calf raise");
+    });
+
+    it("annotates catalog defaults and logged counts", () => {
+        const [top] = searchExercises("barbell bench", [{name: "barbell bench press", count: 7}], CATALOG);
+        expect(top.name).toBe("barbell bench press");
+        expect(top.isDefault).toBe(true);
+        expect(top.loggedCount).toBe(7);
+    });
+
+    it("empty query returns a capped default view, most-logged first", () => {
+        const history = [{name: "hack squat", count: 40}];
+        const result = searchExercises("", history, CATALOG);
+        expect(result.length).toBeGreaterThan(0);
+        expect(result[0].name).toBe("hack squat");
+    });
+
+    it("is case- and whitespace-insensitive on the query", () => {
+        expect(names("  FRONT   Squat ")[0]).toBe("front squat");
+    });
+});

--- a/apps/workout-log/src/app/model/exercise-suggestions.ts
+++ b/apps/workout-log/src/app/model/exercise-suggestions.ts
@@ -1,0 +1,118 @@
+import {normalizeExercise} from "./exercise";
+import {EXERCISE_CATALOG, ExerciseFamily} from "./exercise-catalog";
+
+/** An exercise the user has already logged, with how many times (drives the "log this a lot" boost). */
+export interface KnownExercise {
+    name: string;
+    count: number;
+}
+
+export interface ExerciseSuggestion {
+    /** Canonical name to store when picked. */
+    name: string;
+    /** Family label, when the suggestion comes from the catalog. */
+    family?: string;
+    /** True when this is its family's default variant (variants[0]). */
+    isDefault: boolean;
+    /** How many times the user has logged it (0 = catalog-only, never logged). */
+    loggedCount: number;
+}
+
+interface Candidate extends ExerciseSuggestion {
+    /** Extra searchable text (name + family) so "bench" matches every bench-press variant. */
+    searchText: string;
+    /** Position within the catalog, used as a stable tiebreak so defaults/earlier variants win. */
+    order: number;
+}
+
+export const MAX_SUGGESTIONS = 8;
+
+function buildCandidates(history: KnownExercise[], catalog: ExerciseFamily[]): Candidate[] {
+    const byName = new Map<string, Candidate>();
+
+    let order = 0;
+    for (const {family, variants} of catalog) {
+        variants.forEach((variant, index) => {
+            const name = normalizeExercise(variant);
+            byName.set(name, {
+                name,
+                family,
+                isDefault: index === 0,
+                loggedCount: 0,
+                searchText: `${name} ${family}`,
+                order: order++,
+            });
+        });
+    }
+
+    // Merge in the user's history: annotate matching catalog entries with their count, and add any
+    // logged exercise that isn't in the catalog so custom names still get suggested next time.
+    for (const {name: rawName, count} of history) {
+        const name = normalizeExercise(rawName);
+        if (!name) continue;
+        const existing = byName.get(name);
+        if (existing) {
+            existing.loggedCount = count;
+        } else {
+            byName.set(name, {
+                name,
+                isDefault: false,
+                loggedCount: count,
+                searchText: name,
+                order: order++,
+            });
+        }
+    }
+
+    return Array.from(byName.values());
+}
+
+function matches(candidate: Candidate, tokens: string[]): boolean {
+    return tokens.every((token) => candidate.searchText.includes(token));
+}
+
+/**
+ * Ranks candidates for a query. Priority: exact match, then prefix match, then already-logged
+ * (heavily — by count), then family defaults, then catalog order, then shorter names. The result is
+ * a flat list the combobox renders with "(default)" / "logged N×" annotations.
+ */
+function compare(a: Candidate, b: Candidate, normalizedQuery: string): number {
+    if (normalizedQuery) {
+        const aExact = a.name === normalizedQuery;
+        const bExact = b.name === normalizedQuery;
+        if (aExact !== bExact) return aExact ? -1 : 1;
+
+        const aPrefix = a.name.startsWith(normalizedQuery);
+        const bPrefix = b.name.startsWith(normalizedQuery);
+        if (aPrefix !== bPrefix) return aPrefix ? -1 : 1;
+    }
+
+    const aLogged = a.loggedCount > 0;
+    const bLogged = b.loggedCount > 0;
+    if (aLogged !== bLogged) return aLogged ? -1 : 1;
+    if (a.loggedCount !== b.loggedCount) return b.loggedCount - a.loggedCount;
+
+    if (a.isDefault !== b.isDefault) return a.isDefault ? -1 : 1;
+    if (a.order !== b.order) return a.order - b.order;
+    return a.name.length - b.name.length;
+}
+
+/**
+ * Returns up to MAX_SUGGESTIONS ranked exercise suggestions for what the user has typed. An empty
+ * query yields the "default" view (most-logged first, then family defaults). The combobox is
+ * responsible for offering the raw typed value as a custom "log as new" option on top of these.
+ */
+export function searchExercises(
+    rawQuery: string,
+    history: KnownExercise[] = [],
+    catalog: ExerciseFamily[] = EXERCISE_CATALOG,
+): ExerciseSuggestion[] {
+    const normalizedQuery = normalizeExercise(rawQuery);
+    const tokens = normalizedQuery.split(" ").filter(Boolean);
+
+    const candidates = buildCandidates(history, catalog)
+        .filter((candidate) => matches(candidate, tokens))
+        .sort((a, b) => compare(a, b, normalizedQuery));
+
+    return candidates.slice(0, MAX_SUGGESTIONS).map(({searchText, order, ...suggestion}) => suggestion);
+}

--- a/apps/workout-log/vitest.config.ts
+++ b/apps/workout-log/vitest.config.ts
@@ -2,6 +2,13 @@ import {configDefaults, defineConfig} from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import { resolve } from 'path'
 
+// Force a non-production React build for tests. CI runs `nx test` after `next build` under
+// NODE_ENV=production (Vercel sets it for the whole build); React then loads its production bundle,
+// where @testing-library's act()-based render/cleanup throws "act(...) is not supported in
+// production builds of React". Setting this here (before the fork workers spawn) makes them inherit
+// NODE_ENV=test regardless of the ambient value.
+process.env.NODE_ENV = 'test'
+
 export default defineConfig({
     plugins: [react()],
     test: {

--- a/apps/workout-log/vitest.config.ts
+++ b/apps/workout-log/vitest.config.ts
@@ -2,13 +2,6 @@ import {configDefaults, defineConfig} from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import { resolve } from 'path'
 
-// Force a non-production React build for tests. CI runs `nx test` after `next build` under
-// NODE_ENV=production (Vercel sets it for the whole build); React then loads its production bundle,
-// where @testing-library's act()-based render/cleanup throws "act(...) is not supported in
-// production builds of React". Setting this here (before the fork workers spawn) makes them inherit
-// NODE_ENV=test regardless of the ambient value.
-process.env.NODE_ENV = 'test'
-
 export default defineConfig({
     plugins: [react()],
     test: {
@@ -17,6 +10,12 @@ export default defineConfig({
         // pool hits a libuv fd-close assertion crash on Node 20+ in CI (Vercel runs `nx test` on
         // Node 24), aborting the whole run even though every test passes. Forks avoid it.
         pool: 'forks',
+        // Force a non-production React build for the tests. CI runs `nx test` after `next build`
+        // under NODE_ENV=production (Vercel sets it build-wide); React would then load its
+        // production bundle, where @testing-library's act()-based render/cleanup throws
+        // "act(...) is not supported in production builds of React". Overriding it here keeps the
+        // component tests working regardless of the ambient value.
+        env: {NODE_ENV: 'test'},
         exclude:[
             ...configDefaults.exclude,
             'e2e'

--- a/apps/workout-log/vitest.config.ts
+++ b/apps/workout-log/vitest.config.ts
@@ -6,6 +6,10 @@ export default defineConfig({
     plugins: [react()],
     test: {
         environment: 'jsdom',
+        // Run tests in forked child processes rather than worker threads. Vitest's default thread
+        // pool hits a libuv fd-close assertion crash on Node 20+ in CI (Vercel runs `nx test` on
+        // Node 24), aborting the whole run even though every test passes. Forks avoid it.
+        pool: 'forks',
         exclude:[
             ...configDefaults.exclude,
             'e2e'


### PR DESCRIPTION
> Stacked on #26 (needs `normalizeExercise()`). Review/merge after #26, then this rebases cleanly onto main.

## What

Replaces the plain `<datalist>` on the exercise field with a custom combobox that proposes exercises from a **shipped catalog of families/variants** merged with **your own logged history**, so common variants are one tap away while custom names are never blocked.

- **Token matching**: typing `paused` surfaces every *…paused…* variant across families; `squat` surfaces the whole squat family (matches on family text, so `bench` → all bench-press variants too).
- **Ranking**: exact → prefix → already-logged (by count, heavily favored) → family default → catalog order.
- **Annotations**: `★ (default)` for a family's default variant, `logged N×` for exercises you've done.
- **Custom entry**: an always-present `+ Log "…" as new` row; free text is stored normalized.
- Full keyboard nav (↑/↓/Enter/Esc) + click, `role=combobox`/`listbox` a11y.

## Files
- `model/exercise-catalog.ts` — curated families (single source of truth for suggestions; easy to edit).
- `model/exercise-suggestions.ts` — pure search/rank function (9 unit tests).
- `form/exercise-combobox.tsx` — the UI (5 jsdom component tests).
- `form/log-form.tsx`, `home.tsx` — wiring; home feeds distinct logged exercises + counts.

## Tests
68 unit/component tests green; production build + typecheck pass.

## Open design decisions (see PR discussion)
- **Default naming scheme** for squat/deadlift (bare `squat` vs `barbell squat`), which affects whether the migration also renames those.
- Catalog contents are a first draft seeded from real data — trivial to tune.