### PR TITLE
feat: session duration next to the rest timer

### DIFF
--- a/apps/workout-log/src/app/clockwatch/clock-watch.tsx
+++ b/apps/workout-log/src/app/clockwatch/clock-watch.tsx
@@ -1,6 +1,7 @@
 'use client'
 import React, {forwardRef, Ref, useEffect, useImperativeHandle, useState} from "react";
 import {getDateDiffInSecondsAndMinutes} from "../utils/date-utils";
+import SessionDuration from "./session-duration";
 
 export interface ClockWatchRef {
     resetClockWatch: () => void
@@ -8,6 +9,9 @@ export interface ClockWatchRef {
 
 export interface ClockWatchProps {
     getLastWorkoutDate: () => number | undefined
+    // First set of the session the user is currently in, when they are in one. Its duration is shown
+    // next to the timer, quieter than the timer itself.
+    sessionStartDate?: number
     // Rendered to the right of the timer (e.g. the weekly session counter). Shown even when the
     // timer itself is hidden, so it simply sits centered on its own in that case.
     trailing?: React.ReactNode
@@ -30,7 +34,7 @@ export function displayClockWatch(startDate: Date): {seconds: number, minutes: n
 }
 
 export const ClockWatch = forwardRef((props: ClockWatchProps, ref: Ref<ClockWatchRef>) => {
-    const {getLastWorkoutDate, trailing} = props;
+    const {getLastWorkoutDate, sessionStartDate, trailing} = props;
 
     const [timeToDisplay, setTimeToDisplay] = useState<string | null>(null);
     const [date, setDate] = useState<Date>(new Date(getReferenceDate(getLastWorkoutDate())));
@@ -73,6 +77,7 @@ export const ClockWatch = forwardRef((props: ClockWatchProps, ref: Ref<ClockWatc
             {timeToDisplay ?
                 <div data-testid="custom-element" role={"meter"}>{timeToDisplay}</div> : <></>
             }
+            {sessionStartDate ? <SessionDuration sessionStartDate={sessionStartDate}></SessionDuration> : <></>}
             {trailing}
         </div>
     );

--- a/apps/workout-log/src/app/clockwatch/session-duration.tsx
+++ b/apps/workout-log/src/app/clockwatch/session-duration.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import React, {useEffect, useState} from "react";
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {faStopwatch} from "@fortawesome/free-solid-svg-icons";
+import {formatDurationShort} from "../utils/date-utils";
+
+export interface SessionDurationProps {
+    // First set of the session the user is currently in (epoch ms).
+    sessionStartDate: number
+}
+
+// Session length only matters to the minute, so there is no point re-rendering every second.
+const REFRESH_INTERVAL_IN_MS = 15 * 1000;
+
+/**
+ * How long the current gym session has been running, shown next to the rest timer.
+ * Rendered smaller and more transparent than the timer on purpose: the timer is what the user acts on
+ * between sets, the session length is just ambient context.
+ */
+export default function SessionDuration(props: SessionDurationProps) {
+    const {sessionStartDate} = props;
+
+    const [durationInMs, setDurationInMs] = useState<number>(() => Date.now() - sessionStartDate);
+
+    useEffect(() => {
+        setDurationInMs(Date.now() - sessionStartDate);
+        const id = setInterval(() => setDurationInMs(Date.now() - sessionStartDate), REFRESH_INTERVAL_IN_MS);
+        return () => clearInterval(id);
+    }, [sessionStartDate]);
+
+    return (
+        <div className="inline-flex items-center gap-1 text-sm text-main/50"
+             data-testid="session-duration"
+             title="Time since the first set of this session"
+             aria-label={`Current session lasting ${formatDurationShort(durationInMs)}`}>
+            <FontAwesomeIcon icon={faStopwatch} className="text-xs"/>
+            <span>{formatDurationShort(durationInMs)}</span>
+        </div>
+    );
+}

--- a/apps/workout-log/src/app/history/workout-session.spec.ts
+++ b/apps/workout-log/src/app/history/workout-session.spec.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from 'vitest'
 import {WorkoutRow} from "../workout";
-import {countSessionsThisWeek, groupWorkoutsIntoSessions, resolveSessionId, SESSION_MAX_GAP_IN_MS} from "./workout-session";
+import {countSessionsThisWeek, findOngoingSession, groupWorkoutsIntoSessions, resolveSessionId, SESSION_MAX_GAP_IN_MS} from "./workout-session";
 
 function row(id: string, date: Date, overrides?: { exercise?: string, reps?: number, weight?: number, sessionId?: string }): WorkoutRow {
     return {
@@ -237,5 +237,58 @@ describe('countSessionsThisWeek', () => {
         ];
 
         expect(countSessionsThisWeek(workouts, july22)).toEqual(1);
+    })
+})
+
+describe('findOngoingSession', () => {
+    it('finds no session when nothing has been logged', () => {
+        expect(findOngoingSession([], new Date("2024-07-13T10:00:00"))).toBeUndefined();
+    })
+
+    it('finds the current session and its first set when the last set is recent', () => {
+        const now = new Date("2024-07-13T11:00:00");
+        const workouts = [
+            row("3", new Date("2024-07-13T10:40:00"), {sessionId: "session-A"}),
+            row("2", new Date("2024-07-13T10:20:00"), {sessionId: "session-A"}),
+            row("1", new Date("2024-07-13T10:00:00"), {sessionId: "session-A"}),
+        ];
+
+        const session = findOngoingSession(workouts, now);
+
+        expect(session?.sessionId).toEqual("session-A");
+        expect(session?.startDate).toEqual(new Date("2024-07-13T10:00:00").valueOf());
+    })
+
+    it('finds no session when the last set is older than the session gap', () => {
+        const now = new Date("2024-07-13T16:00:00");
+        const workouts = [
+            row("1", new Date("2024-07-13T10:00:00"), {sessionId: "session-A"}),
+        ];
+
+        expect(findOngoingSession(workouts, now)).toBeUndefined();
+    })
+
+    it('ignores older sessions and only considers the most recent one', () => {
+        const now = new Date("2024-07-13T10:30:00");
+        const workouts = [
+            row("2", new Date("2024-07-13T10:20:00"), {sessionId: "session-B"}),
+            row("1", new Date("2024-07-12T18:00:00"), {sessionId: "session-A"}),
+        ];
+
+        const session = findOngoingSession(workouts, now);
+
+        expect(session?.sessionId).toEqual("session-B");
+        expect(session?.workouts).toHaveLength(1);
+    })
+
+    it('spans a spuriously-split session so the duration covers the whole gym visit', () => {
+        const now = new Date(1784743700000);
+        const workouts = [
+            row("QYFTun", new Date(1784743631556), {sessionId: "7ded470d"}),
+            row("oCr4uV", new Date(1784742507438), {sessionId: "64649f8d"}),
+            row("KbvXzC", new Date(1784741776900), {sessionId: "64649f8d"}),
+        ];
+
+        expect(findOngoingSession(workouts, now)?.startDate).toEqual(1784741776900);
     })
 })

--- a/apps/workout-log/src/app/history/workout-session.ts
+++ b/apps/workout-log/src/app/history/workout-session.ts
@@ -89,6 +89,25 @@ export function countSessionsThisWeek(workouts: WorkoutRow[], now: Date = new Da
         .length;
 }
 
+/**
+ * Returns the session the user is currently in, or `undefined` when they are not training right now.
+ * A session is "ongoing" when its last set was logged no longer than `maxGapInMs` ago — the same window
+ * that decides whether a new log extends a session, so this stays consistent with `resolveSessionId`.
+ *
+ * `workouts` must be sorted most-recent-first, as returned by `getMostRecents`. `now` is injectable for testing.
+ */
+export function findOngoingSession(workouts: WorkoutRow[], now: Date = new Date(), maxGapInMs: number = SESSION_MAX_GAP_IN_MS): WorkoutSession | undefined {
+    if (workouts.length === 0) {
+        return undefined;
+    }
+
+    const mostRecentSession = groupWorkoutsIntoSessions(workouts, maxGapInMs)[0];
+    if (now.valueOf() - mostRecentSession.endDate > maxGapInMs) {
+        return undefined;
+    }
+    return mostRecentSession;
+}
+
 function belongToSameSession(a: WorkoutRow, b: WorkoutRow, maxGapInMs: number): boolean {
     if (a.value.sessionId && b.value.sessionId && a.value.sessionId === b.value.sessionId) {
         return true;

--- a/apps/workout-log/src/app/home.tsx
+++ b/apps/workout-log/src/app/home.tsx
@@ -19,6 +19,7 @@ import {UsualLift} from "./model/usual-lift";
 import {findUsualLiftFromDb} from "./firestore/WorkoutStatisticsFirestore";
 import WorkoutHistoryPage from "./history/workout-history-page";
 import WeeklySessionCounter from "./workout-overview/weekly-session-counter";
+import {findOngoingSession} from "./history/workout-session";
 
 export interface HomeProps {
     userID: UserID
@@ -94,6 +95,10 @@ export default function Home(props: HomeProps) {
         return Array.from(counts.entries()).map(([name, count]) => ({name, count}));
     }, [workoutRecentHistory]);
 
+    // The session the user is training in right now, if any — recomputed whenever a new set lands, so the
+    // displayed session duration starts from the first set of the current gym visit.
+    const ongoingSession = useMemo(() => findOngoingSession(workoutRecentHistory), [workoutRecentHistory]);
+
     const findBestWorkoutPerformance = async (exercice: string) => {
         setBestWorkoutPerformance(await findPersonalBest(userID, exercice, db));
     }
@@ -143,6 +148,7 @@ export default function Home(props: HomeProps) {
                         </div>
                         <ClockWatch getLastWorkoutDate={() => getLastWorkoutInputInLocalStorage()?.date}
                                     ref={clockWatchChildRef}
+                                    sessionStartDate={ongoingSession?.startDate}
                                     trailing={<WeeklySessionCounter workoutList={workoutRecentHistory}></WeeklySessionCounter>}></ClockWatch>
                         <div>
                             <LogForm onWorkoutLog={onWorkoutLog} onExerciseSelected={onExerciseSelected}

--- a/apps/workout-log/src/app/utils/date-utils.spec.tsx
+++ b/apps/workout-log/src/app/utils/date-utils.spec.tsx
@@ -1,4 +1,4 @@
-import {formatFullDateTime, formatNarrowSmartly, getDateDiffInSecondsAndMinutes, startOfIsoWeek} from "./date-utils";
+import {formatDurationShort, formatFullDateTime, formatNarrowSmartly, getDateDiffInSecondsAndMinutes, startOfIsoWeek} from "./date-utils";
 import {describe, expect, it} from 'vitest'
 
 const US_LOCALE = new Intl.Locale('en-US');
@@ -115,5 +115,27 @@ describe('date diff tests', () => {
         const res = getDateDiffInSecondsAndMinutes(new Date("2024-07-12T08:08:00"), new Date("2024-07-12T09:08:30"));
 
         expect(res).toEqual({minutes: 60, seconds: 30});
+    })
+})
+
+describe('formatDurationShort', () => {
+    it('shows minutes only under an hour', () => {
+        expect(formatDurationShort(47 * 60 * 1000)).toEqual("47m");
+    })
+
+    it('shows 0m for a session that just started', () => {
+        expect(formatDurationShort(12 * 1000)).toEqual("0m");
+    })
+
+    it('pads the minutes once past an hour', () => {
+        expect(formatDurationShort((60 + 7) * 60 * 1000)).toEqual("1h07");
+    })
+
+    it('shows a whole number of hours', () => {
+        expect(formatDurationShort(2 * 60 * 60 * 1000)).toEqual("2h00");
+    })
+
+    it('never shows a negative duration', () => {
+        expect(formatDurationShort(-5000)).toEqual("0m");
     })
 })

--- a/apps/workout-log/src/app/utils/date-utils.ts
+++ b/apps/workout-log/src/app/utils/date-utils.ts
@@ -42,6 +42,22 @@ export function startOfIsoWeek(date: Date): Date {
     return result;
 }
 
+/**
+ * Compact elapsed-duration label for the ongoing session, e.g. `0m`, `47m`, `1h07`.
+ * Deliberately terser than the rest timer (which counts seconds) — session length only matters
+ * to the minute, and it sits next to the timer where space is tight.
+ */
+export function formatDurationShort(durationInMs: number): string {
+    const totalMinutes = Math.max(0, Math.floor(durationInMs / (1000 * 60)));
+    const hours = Math.floor(totalMinutes / 60);
+    const minutes = totalMinutes % 60;
+
+    if (hours === 0) {
+        return `${minutes}m`;
+    }
+    return `${hours}h${String(minutes).padStart(2, '0')}`;
+}
+
 export function getDateDiffInSecondsAndMinutes(d1: Date, d2: Date): { seconds: number, minutes: number } {
     let timer = new Date(Math.abs(d1.getTime() - d2.getTime()));
 


### PR DESCRIPTION
## What

When the app detects the user is **in a session** (last set logged within the 3h `SESSION_MAX_GAP_IN_MS` window), the duration of that session is now shown next to the rest timer — smaller and more transparent than the timer, since the timer is what you act on between sets while the session length is just ambient context.

## How

- `findOngoingSession` (`history/workout-session.ts`) — takes the most recent grouped session and returns it only if its last set is within the session gap. Reuses `groupWorkoutsIntoSessions`, so a spuriously-split session still yields the true start of the gym visit.
- `formatDurationShort` (`utils/date-utils.ts`) — compact minute-granularity label: `0m`, `47m`, `1h07`.
- `SessionDuration` (`clockwatch/session-duration.tsx`) — stopwatch icon + label at `text-sm text-main/50`, refreshed every 15s (no point ticking every second for minute granularity).
- `ClockWatch` gains an optional `sessionStartDate`; `home.tsx` derives it from the already-fetched recent history via `useMemo`, so no extra Firestore reads.

## Tests

10 new unit tests (5 for `findOngoingSession`, 5 for `formatDurationShort`). Full suite: 84/84 pass. `nx build workout-log` type-checks clean.