### PR TITLE
feat: show 20 recent logs on the main page

### DIFF
--- a/apps/workout-log/src/app/home.tsx
+++ b/apps/workout-log/src/app/home.tsx
@@ -29,7 +29,7 @@ export interface HomeProps {
 // session counter has enough data to count every session since Monday.
 const WORKOUT_FETCH_LIMIT = 50;
 // How many recent workouts the "last workouts" list renders (the rest only feed the weekly counter).
-const SHORT_HISTORY_LIMIT = 10;
+const SHORT_HISTORY_LIMIT = 20;
 
 export default function Home(props: HomeProps) {
     const {userID} = props;


### PR DESCRIPTION
The recent-logs list on the home page rendered only the last 10 entries. Bumped `SHORT_HISTORY_LIMIT` to 20.

No extra Firestore reads: `WORKOUT_FETCH_LIMIT` is already 50, so the additional 10 rows come from data we were fetching anyway (it feeds the weekly session counter).

All 84 unit tests pass.